### PR TITLE
docs(eip3009): scope the not-a-server-dependency rule to the server binary

### DIFF
--- a/eip3009/src/lib.rs
+++ b/eip3009/src/lib.rs
@@ -5,10 +5,14 @@
 //! signature, over this authorization, recover to this address?* — which is the question an x402
 //! facilitator answers on the `/verify` path.
 //!
-//! It is deliberately **not** a dependency of the Obolus gateway binary. Obolus delegates
-//! verification to a facilitator and never inspects a signature itself; pulling secp256k1 into the
-//! shipped binary's graph to serve a development stub would widen that binary's attack surface for
-//! something it does not do.
+//! It is deliberately **not** a dependency of the `server` binary. That gateway delegates
+//! verification to a facilitator and never inspects a signature itself, so pulling secp256k1 into its
+//! graph would widen the shipped artifact's attack surface for something it does not do.
+//!
+//! The rule is scoped to `server`, not to this crate's consumers in general — it is about what the
+//! gateway's graph contains, not about who may verify. A binary whose job *is* to inspect signatures
+//! links this crate by design: a development seller that checks payments offline, so an x402 client
+//! can be tested against a counterparty that fails on command, is the intended second consumer.
 
 use sha3::{Digest, Keccak256};
 


### PR DESCRIPTION
## Summary

The crate doc says `eip3009` is "not a dependency of the Obolus gateway binary" and gives as its reason
that pulling secp256k1 in "to serve a development stub" would widen the shipped binary's attack surface.
Read literally that forbids the one use the crate was built for, since offline verification for a
development counterparty is exactly what a development stub does.

The reasoning is right; only its scope was unstated. The rule is about what **`server`'s** dependency
graph contains — that binary delegates verification to a facilitator and never inspects a signature, so
crypto has no business there. It is not a rule about who may verify. A separate binary whose job *is* to
inspect signatures adds nothing to `server`'s graph and is the crate's intended second consumer.

This states that scope explicitly, so the tension does not get resolved later by deleting the offline
verification path instead. `//eip3009` stays absent from `//obolus:server`; nothing about the shipped
gateway changes.

Doc comment only — no code, no dependency edges, no behaviour.

See OBOL-018.

## Affected machines / services

- None. A `//!` doc block in `eip3009/src/lib.rs`.
- No change to any BUILD file, dependency edge, or shipped artifact. `//obolus:server` is untouched.

## Validation performed

- [x] `bazel test //eip3009:all` — 1 target, `//eip3009:eip3009_test` PASSED (11 KAT-driven tests).
- [ ] kubectl dry-run (N/A — no manifests)
- [ ] sops decrypt (N/A — no secrets)
- [x] Wording checked against the repo's own invariant, which already scoped this correctly
      ("not a dep of `//obolus:server` … exists for offline verification + dev stubs"). This aligns the
      crate doc with it rather than introducing a new claim.

## Deployment steps (POST-MERGE)

- None. Documentation change; nothing is deployed from this crate.

## Tickets addressed

- see OBOL-018

## Rollback

- Revert this PR. It restores the previous wording of one doc block; no code depends on it.
