### PR TITLE
Run the cargo half of the dual build in CI, and fix what it found

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,22 @@ jobs:
       # is the gate that decides a merge; anything touching external reality runs outside it.
       - name: Test
         run: bazel test //...
+
+  cargo:
+    name: cargo test --workspace --locked
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # The other half of the dual build. Bazel above is canonical and cargo is the ergonomic path,
+      # but AGENTS.md names both as merge gates, so both run here rather than one of them running
+      # only on whichever machine a contributor happens to use. Both resolve their dependencies from
+      # the same Cargo.lock, so a dependency-level disagreement between them is a real defect.
+      #
+      # The toolchains are deliberately NOT pinned together: MODULE.bazel fixes Rust 1.90.0, and this
+      # job takes whatever stable the runner ships. Pinning a second version here would only prove
+      # the pin agrees with itself. The cost of that choice is worth stating plainly — a failure here
+      # that the Bazel job does not see may be a compiler difference rather than a defect, because
+      # `--locked` holds the dependency graph fixed and says nothing about the compiler.
+      - name: Test
+        run: cargo test --workspace --locked

--- a/obolus/tests/server_arming.rs
+++ b/obolus/tests/server_arming.rs
@@ -358,9 +358,9 @@ impl Run {
 
 /// Write a fixture file for the child to read and hand back its path.
 ///
-/// Under Bazel `TEST_TMPDIR` is the per-test scratch directory that the runner owns and cleans up;
-/// `temp_dir()` is the fallback for a plain `cargo`-style run, which this repo does not use but
-/// which should not silently write somewhere surprising either.
+/// Under Bazel `TEST_TMPDIR` is the per-test scratch directory that the runner owns and cleans up.
+/// Cargo has no equivalent, so a cargo run falls back to `temp_dir()` — shared, and not cleaned up
+/// for us, which is why every caller passes a distinct name.
 fn temp_file(name: &str, contents: &str) -> String {
     let dir = std::env::var("TEST_TMPDIR")
         .map(std::path::PathBuf::from)
@@ -372,8 +372,18 @@ fn temp_file(name: &str, contents: &str) -> String {
 
 /// Run the real server binary to completion with `vars` applied over a fixed, valid baseline.
 fn run(vars: &[(&str, &str)]) -> Run {
+    // Both halves of the dual build, because both are supposed to pass. Bazel passes the path
+    // through the rule's `env`; cargo sets `CARGO_BIN_EXE_<bin>` at compile time. `option_env!`
+    // rather than `env!` because the latter is a compile error under Bazel, where cargo's variable
+    // does not exist. The explicit variable wins where both are available, so pointing this suite at
+    // some other build of the binary stays possible.
     let bin = std::env::var("OBOLUS_SERVER_BIN")
-        .expect("OBOLUS_SERVER_BIN must be set by the BUILD rule's env (see BUILD.bazel)");
+        .ok()
+        .or_else(|| option_env!("CARGO_BIN_EXE_obolus").map(str::to_string))
+        .expect(
+            "no obolus server binary to run: OBOLUS_SERVER_BIN is unset (Bazel sets it from the \
+             rule's env — see BUILD.bazel) and this was not built by cargo either",
+        );
 
     // Occupy a loopback port and hand it to the child so that bind — the last statement of
     // startup — always fails. See the module docs.


### PR DESCRIPTION
## Prerequisites

- [ ] N/A — this is the base of a two-PR stack. The child adds `obolus-devseller` (OBOL-018).

## Summary

`AGENTS.md` §BUILD names two merge gates:

```
bazel test //...
cargo test --workspace --locked
```

CI ran only the first, and the second had been failing on `main`. `obolus/tests/server_arming.rs`
locates the `server` binary through `OBOLUS_SERVER_BIN`, which is set by exactly one thing — the
`env` attribute of the `server_arming_test` rule in `obolus/BUILD.bazel`. Under plain cargo nothing
sets it, the `expect` fires, and **32 of that file's 33 tests fail**. `cargo build` succeeds, so
nothing warned; the only signal was running a command CI never ran.

Two changes, and the second is the one that matters:

- **The test resolves the binary under either build.** It falls back to
  `option_env!("CARGO_BIN_EXE_obolus")`, cargo's own compile-time variable. `option_env!` rather than
  `env!` is load-bearing: that variable does not exist under Bazel, and `env!` would fail the *Bazel*
  build at compile time. Bazel keeps supplying the path through the rule's `env` exactly as before.
- **A `cargo` job added to `.github/workflows/ci.yml`**, GitHub-hosted like every other job here. The
  first change repairs the gate; only this one makes it *be* a gate. A documented gate that nothing
  runs is how this stayed red on `main` without anyone noticing.

**One step remains, and it is not in this diff.** A job that runs and reports is not yet a job that
*blocks*: making it blocking means adding `cargo test --workspace --locked` to the `main` branch's
required-status-checks list, which is a repository setting rather than a file. Until that is done the
enforcement is `gh-pr-merge`'s own CI validation plus whoever is merging. Listed under Deployment
steps.

The job uses the runner's preinstalled stable toolchain rather than pinning a second Rust version,
which would only prove the pin agrees with itself. Both builds resolve dependencies from the same
`Cargo.lock`, so a dependency-level disagreement is a real defect — but the toolchains are
deliberately *not* pinned together (`MODULE.bazel` fixes 1.90.0), so a cargo-only failure can also be
a compiler difference. `--locked` holds the dependency graph fixed and says nothing about the
compiler.

Note the binary name: OBOL-020 anticipated needing a `[[bin]] name = "server"` stanza so that
`CARGO_BIN_EXE_server` would exist, since cargo names an auto-discovered binary after the *package*.
Reading `CARGO_BIN_EXE_obolus` instead — the name cargo actually uses — makes the manifest change
unnecessary. One file changed rather than two.

## Affected machines / services

- None. This changes a test file and a CI workflow. No library, binary, or deployed artifact is
  touched, and nothing in `obolus/src/` changes.

## Validation performed

- [x] Both gates pass **at this commit**, as measured by this PR's own CI rather than by me. That
      distinction matters here: my local runs were on the stack tip, where the child PR's `devseller`
      package also exists, so the "5 Bazel targets" I could quote locally is not this commit's
      number — at this commit the workspace has two members and three test targets.
- [x] `cargo test --workspace --locked` passes with no warnings. `server_arming` goes from
      **1 passed / 32 failed** to **33/33**.
- [x] Review round 1 fixes applied: a stale doc comment in `server_arming.rs` that called cargo a
      run "this repo does not use" (contradicted by the job added here), and a self-contradicting
      comment in the new job about what `--locked` covers.
- [ ] kubectl dry-run passed (N/A — no manifests in this repository)
- [ ] sops decrypt verified (N/A — no secrets touched)

## Deployment steps (POST-MERGE)

- Nothing is deployed. The new job reports on the next pull request automatically.
- **Manual, and required for this to actually block:** add `cargo test --workspace --locked` to
  `main`'s required-status-checks list. That is a repository setting rather than a file, so this PR
  cannot do it, and it needs someone with admin on the repo. Until then the job reports but does not
  gate — `gh-pr-merge`'s own CI validation is what stands in.

## Tickets addressed

- see OBOL-020

## Rollback

- Revert the commit. The `cargo` job disappears with it and `bazel test //...` remains the sole gate,
  which is the status quo ante — including the latent cargo failure this PR fixes.
