### PR TITLE
ci: publish release binaries, built by Bazel from a renamed //obolus:obolus target (OBOL-025)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,3 +3,20 @@
 
 # Per-user local overrides (gitignored). Optional — an absent file is fine.
 try-import %workspace%/user.bazelrc
+
+# How published artifacts are built. Optimised, but with arithmetic that still fails loudly:
+# `overflow-checks` is a knob separate from `debug-assertions` and from optimisation level, so the
+# apparent trade — ship an unoptimised binary, or lose overflow panics — is not a real one. This is a
+# payment gateway, and an amount that silently wraps is a wrong answer that survives, where a panic
+# is a request that dies.
+#
+# The flag reaches every Rustc action in the target configuration, third-party crates included.
+# Exec-configuration actions (build scripts, proc-macros) do not receive it and do not need it: they
+# run at build time and none of their code reaches the artifact.
+#
+# Living here rather than in the workflow means `bazel build --config=release //obolus` reproduces
+# the published binary, instead of the incantation being knowable only by reading CI. Cargo.toml
+# carries the same setting in `[profile.release]`, so the two builds agree on arithmetic. See
+# OBOL-025.
+build:release --compilation_mode=opt
+build:release --@rules_rust//rust/settings:extra_rustc_flags=-Coverflow-checks=on

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,227 @@
+name: Release
+
+# Publishes the binaries. Two entry points, deliberately:
+#
+#   - a push to `main` cuts an immutable pre-release tagged `main-<sha>`, so every merged change has
+#     downloadable bytes without anyone copying a file by hand. Pre-release, so the repository's
+#     front page keeps pointing at the newest real version rather than at whatever landed last.
+#   - a `v*` tag cuts the real thing.
+#
+# There is deliberately no `pull_request` trigger. This repository is public, so a pull request
+# carries code from someone we do not know; a workflow that both runs a stranger's patch and holds a
+# `contents: write` token is how a release gets replaced by whoever opened the PR. Every trigger
+# below is reachable only by someone who already has write access.
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+# Read-only by default. Exactly one job below widens this, and only to `contents: write`.
+permissions:
+  contents: read
+
+# Two merges landing together produce two distinct `main-<sha>` tags, so they cannot collide — but
+# they are serialised anyway rather than cancelled, because a cancelled run can leave a release
+# created with only part of its assets attached.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      # One job per target, and each builds natively — no cross-compilation. That is not just
+      # simpler: a natively-built artifact is produced on the same machine that just ran the test
+      # suite, so what ships is what was tested. A cross-built macOS binary would be an artifact no
+      # test on this repository had ever executed, which is the wrong property for a payment
+      # gateway. x86_64 macOS is deliberately absent — GitHub retires that image after macOS 15.
+      fail-fast: false
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            runner: macos-latest
+            arch_pattern: 'Mach-O.*arm64'
+          - target: x86_64-unknown-linux-gnu
+            runner: ubuntu-latest
+            arch_pattern: 'ELF.*x86-64'
+          - target: aarch64-unknown-linux-gnu
+            runner: ubuntu-24.04-arm
+            arch_pattern: 'ELF.*aarch64'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      # The whole suite, under the SAME configuration the artifacts are built with — which is what
+      # makes "the thing shipped is the thing tested" literal here rather than approximate.
+      # `//obolus:server_arming_test` takes the binary as a data dependency, so the process it runs
+      # is the same action output the Build step publishes, not a second compilation that happens to
+      # agree. That guard is the only vantage point from which "the arming check runs, and runs
+      # before anything is advertised" is checkable at all.
+      - name: Test
+        run: bazel test --config=release //...
+
+      # `--config=release` is defined in .bazelrc, not spelled out here, so
+      # `bazel build --config=release //obolus` reproduces the published binary for anyone — the
+      # build is not knowable only by reading CI.
+      - name: Build
+        run: bazel build --config=release //obolus //devseller:obolus-devseller
+
+      # `cquery --output=files` rather than a hardcoded `bazel-bin/…` path: that convenience symlink
+      # points at whichever configuration built last, so it would silently hand over a default-mode
+      # binary if anything ever built without `--config=release` first. cquery answers for the
+      # configuration actually asked about.
+      - name: Stage assets
+        run: |
+          mkdir -p dist
+          cp "$(bazel cquery --config=release //obolus --output=files)" "dist/obolus-${{ matrix.target }}"
+          cp "$(bazel cquery --config=release //devseller:obolus-devseller --output=files)" "dist/obolus-devseller-${{ matrix.target }}"
+          chmod +w dist/*
+
+      # Bazel builds for the host, so no flag in the build itself would catch a matrix row whose
+      # runner and triple disagree — it would publish the wrong architecture under the right name,
+      # and nothing before a user's failed execution would say so. Checking the produced file rather
+      # than the build configuration catches that, on the bytes that actually ship.
+      - name: Verify each artifact matches the label it ships under
+        run: |
+          file dist/*
+          file "dist/obolus-${{ matrix.target }}" | grep -qE '${{ matrix.arch_pattern }}'
+          file "dist/obolus-devseller-${{ matrix.target }}" | grep -qE '${{ matrix.arch_pattern }}'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: obolus-${{ matrix.target }}
+          path: dist/
+          if-no-files-found: error
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    # The only elevated job in this file, and it builds nothing — it just attaches what the matrix
+    # produced. Keeping the write token out of the jobs that compile code means a dependency's build
+    # script never runs in a step that could rewrite a release.
+    #
+    # Naming `permissions` at job level sets every scope not listed here to `none`, so `actions: read`
+    # is spelled out rather than assumed: same-run artifact downloads happen to use the runner's own
+    # token today, and a workflow that depends on that staying true would fail here — in the one job
+    # holding a write token, on a path that cannot be exercised before merge.
+    permissions:
+      actions: read
+      contents: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: staging
+
+      # Checksums are computed here rather than on each build runner, so that they cover the bytes
+      # actually about to be published rather than bytes that were correct before transport — a hash
+      # taken before an upload attests to something other than what a downloader receives. Doing it
+      # in one place on one OS also avoids depending on which hashing tool each runner image ships,
+      # which differs between macOS and Linux and is not a thing this workflow should have to track.
+      #
+      # The sidecar is written in `sha256sum` format, so a downloader verifies with
+      # `sha256sum -c obolus-<target>.sha256` and needs nothing from us to do it.
+      - name: Collect and checksum
+        working-directory: staging
+        run: |
+          mkdir -p ../dist
+          find . -type f -exec mv {} ../dist/ \;
+          cd ../dist
+          for f in *; do sha256sum "$f" > "$f.sha256"; done
+          ls -la
+
+      - name: Resolve release identity
+        id: id
+        env:
+          REF: ${{ github.ref }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ "${REF#refs/tags/}" != "$REF" ]; then
+            echo "tag=${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=" >> "$GITHUB_OUTPUT"
+            echo "title=${REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=main-$(echo "$SHA" | cut -c1-12)" >> "$GITHUB_OUTPUT"
+            echo "prerelease=--prerelease" >> "$GITHUB_OUTPUT"
+            echo "title=main @ $(echo "$SHA" | cut -c1-12)" >> "$GITHUB_OUTPUT"
+          fi
+
+      # The release page is where the dangerous mistake gets made. Two binaries ship here and one of
+      # them can be configured to accept every payment presented to it; a stranger reading this page
+      # has none of the context that makes that obviously a test tool. Asset names alone are one
+      # hyphen apart, so the notes have to carry the distinction too.
+      - name: Compose notes
+        env:
+          TAG: ${{ steps.id.outputs.tag }}
+        run: |
+          cat > notes.md <<'NOTES'
+          ## Which binary do I want?
+
+          **`obolus-<target>` — the gateway.** This is the one you deploy. It takes payment for a
+          request before it forwards that request upstream.
+
+          **`obolus-devseller-<target>` — NOT a gateway. Do not deploy this.** It is a seller that
+          can be configured to fail on command, so that people writing x402 *clients* have something
+          to test against: real providers do not fail to order.
+
+          What makes it safe to publish is enforced at startup, not left to the reader:
+
+          - It settles nothing. Its receipts are synthetic, so no money moves whatever you configure.
+          - It refuses to start on any network that is not a testnet, and the arming override that
+            exists elsewhere is refused here rather than honoured.
+          - It binds to `127.0.0.1` by default, and the genuinely dangerous combination — a
+            reachable address, plus accept-everything mode, plus a real upstream — is refused
+            outright, because that is an unauthenticated open proxy to somebody's inference
+            endpoint. Reach it from a device with a port forward rather than a wider bind.
+
+          ## Verifying a download
+
+          Each asset has a `.sha256` sidecar in `sha256sum` format:
+
+          ```
+          sha256sum -c obolus-aarch64-apple-darwin.sha256
+          chmod +x obolus-aarch64-apple-darwin
+          ```
+
+          A downloaded asset does not carry an executable bit — GitHub release downloads never do —
+          so `chmod +x` is expected, not a sign anything is wrong.
+
+          ## Build
+
+          Built from this commit with `bazel build --config=release`, natively on each target's own
+          architecture. The test suite ran on the same machine under the same configuration, and the
+          startup-guard test takes the binary as a dependency, so the process it exercised is the
+          artifact attached here rather than a separate build of the same source.
+
+          Arithmetic overflow panics rather than wrapping. `cargo build --release` reproduces the
+          same behaviour for anyone who would rather not install Bazel.
+          NOTES
+          echo "Notes composed for $TAG"
+
+      - name: Publish
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # This job deliberately does not check out the repository — it compiles nothing and only
+          # needs the artifacts. That leaves `gh` with no git remote to infer the repository from,
+          # so it is named explicitly rather than implied.
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ steps.id.outputs.tag }}
+          TITLE: ${{ steps.id.outputs.title }}
+          PRERELEASE: ${{ steps.id.outputs.prerelease }}
+        run: |
+          gh release create "$TAG" \
+            --target "${{ github.sha }}" \
+            --title "$TITLE" \
+            --notes-file notes.md \
+            $PRERELEASE \
+            dist/*

--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -5,13 +5,15 @@ layer:repo scope:obolus visibility:PUBLIC
 §PURPOSE
 Obolus = x402(HTTP-402) payment-gated serving gateway; toll booth in front of an AI/agentic service
 unpaid req→real 402 challenge→per-request USDC micropayment→passage to model behind it
-crates: obolus/=gateway(protocol edges, Facilitator+Upstream seams, arming guard, `server` bin) | eip3009/=offline EIP-3009/EIP-712 verification driven by published KAT vectors
+crates: obolus/=gateway(protocol edges, Facilitator+Upstream seams, arming guard, `obolus` bin) | eip3009/=offline EIP-3009/EIP-712 verification driven by published KAT vectors | devseller/=`obolus-devseller` bin, a seller to test x402 CLIENTS against(real challenges, offline verify, fails on command; settles nothing, refuses non-testnet, binds loopback)
+devseller = own package NOT 2nd bin under obolus/ [cargo declares deps per PACKAGE→eip3009 entry in obolus/Cargo.toml would put sig-verification in gateway's own graph=what §INVARIANTS forbid; bazel per-target deps could express it, cargo cannot; rule holding under only one of two builds is not a rule]
 repo root = VIRTUAL cargo workspace(no package of its own; member list + shared dep versions only)
 
 §BUILD
 bazel=canonical; cargo=ergonomics, CI-verified; BOTH must pass
   bazel test //...
   cargo test --workspace --locked
+published artifacts: `--config=release`(.bazelrc)=opt + overflow-checks on, reproducible by anyone→`bazel build --config=release //obolus`; Cargo.toml [profile.release] carries same overflow-checks so cargo build --release agrees
 Cargo.lock=single source of truth for versions; MODULE.bazel resolves crates from same manifests→builds cannot silently diverge
 every test hermetic(no network|chain|model)=the ONLY merge gate; external reality(real testnet settle vs 3rd-party facilitator)=out-of-band so its flakiness can't block pipeline
 
@@ -26,7 +28,7 @@ CI on GitHub-hosted runners ONLY; NEVER runs-on:self-hosted [public repo→PR ru
 §INVARIANTS [load-bearing; each test-enforced; each easy to break while improving something else]
 no cryptography in gateway crate: Phase A delegates verify+settle to facilitator behind Facilitator seam; no sig checking|key handling|on-chain submission
   ∴ not mainnet-capable BY CONSTRUCTION(no signing path to misuse); payment payload OPAQUE(decode envelope, forward inner authorization untouched)
-eip3009 deliberately NOT a dep of //obolus:server [exists for offline verification+dev stubs; wiring it in = quietly giving the binary a crypto path]
+eip3009 deliberately NOT a dep of //obolus:obolus [exists for offline verification+dev stubs; wiring it in = quietly giving the binary a crypto path]
 fakes are #[cfg(test)]-only: FakeFacilitator accepts unexamined payments, FakeUpstream serves canned bytes; physically absent from shipped artifacts→no config selects "accept every payment + serve real model"
 arming-guard allowlist = TRANSCRIPTION of upstream source, not curated list; x402 adds a testnet→add to TESTNET_NETWORKS in obolus/src/arming.rs as reviewed code change; NEVER work around w/ OBOLUS_ALLOW_MAINNET [operator setting flag as routine ceremony has already lost the protection]
 nothing we author decides whether a signer is correct [we'd author both sides→shared EIP-712 domain-separator misunderstanding makes both agree while real facilitator rejects]; load-bearing checks OUTSIDE our authorship: published KAT vectors + real testnet settle vs 3rd-party facilitator

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,19 @@ Obolus is an **x402 (HTTP-402) payment-gated serving gateway** — a toll booth 
 agentic service. It answers an unpaid request with a real 402 challenge, takes a per-request USDC
 micropayment, and grants passage to the model behind it.
 
-Two crates:
+Three crates:
 
 | Path | Crate | What it is |
 |---|---|---|
-| `obolus/` | `obolus` | The gateway: protocol edges, the `Facilitator` and `Upstream` seams, the arming guard, the `server` binary |
+| `obolus/` | `obolus` | The gateway: protocol edges, the `Facilitator` and `Upstream` seams, the arming guard, the `obolus` binary |
 | `eip3009/` | `eip3009` | Offline EIP-3009 / EIP-712 authorization verification, driven by published known-answer vectors |
+| `devseller/` | `obolus-devseller` | A seller to test an x402 *client* against: real challenges, offline verification, and failure on command. Settles nothing, refuses any non-testnet network, binds loopback |
+
+`devseller/` is a package of its own rather than a second binary under `obolus/` because cargo
+declares dependencies per package: an `eip3009` entry in `obolus/Cargo.toml` would put a
+signature-verification path in the gateway's own graph, which is precisely what the invariants below
+forbid. Bazel's per-target `deps` could have expressed it; cargo cannot, and a rule that holds under
+only one of the two builds is not a rule.
 
 The repository root is a virtual Cargo workspace — it carries no package of its own, only the
 member list and the shared dependency versions.
@@ -38,6 +45,17 @@ cargo test --workspace --locked
 
 Both must pass. `Cargo.lock` is the single source of truth for versions — `MODULE.bazel` resolves
 third-party crates from the same manifests, so the two builds cannot silently diverge.
+
+Published artifacts are built with the `release` config, which is defined in `.bazelrc` rather than
+in CI so that anyone can reproduce a released binary:
+
+```bash
+bazel build --config=release //obolus
+```
+
+It sets optimisation on and keeps overflow checks on — separate knobs, so an optimised binary need
+not give up the arithmetic that panics rather than wrapping. `Cargo.toml`'s `[profile.release]`
+carries the same overflow setting, so `cargo build --release` agrees.
 
 Every test is hermetic: no network, no chain, no model. That is deliberate, and it is the only CI
 that gates a merge. Anything that touches external reality — a real testnet settle against a
@@ -70,7 +88,7 @@ something else better.
   on-chain submission — so the binary is not mainnet-capable by construction, because there is no
   signing path to misuse. The payment payload is opaque: we decode the envelope and forward the
   inner authorization untouched.
-- **`eip3009` is deliberately not a dependency of `//obolus:server`.** It exists for offline verification
+- **`eip3009` is deliberately not a dependency of `//obolus:obolus`.** It exists for offline verification
   and development stubs. Wiring it into the gateway would quietly give the binary a crypto path.
 - **The fakes are `#[cfg(test)]`-only.** `FakeFacilitator` accepts payments it never examined and
   `FakeUpstream` serves canned bytes. They are physically absent from every shipped artifact, so no

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,16 @@ rust-version = "1.90.0"
 thiserror = "2.0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+
+# Optimised, but with arithmetic that still fails loudly. `overflow-checks` is a separate knob from
+# `debug-assertions` and from `opt-level`, so the apparent trade — ship an unoptimised binary, or
+# lose overflow panics — is not a real one. This is a payment gateway: an amount that silently wraps
+# is a wrong answer that survives, where a panic is a request that dies. The property genuinely
+# traded away is worth naming rather than discovering: a panicking overflow reachable from untrusted
+# input is an availability fault, so overflow belongs to whatever hardening pass owns panic-safety at
+# the request boundary.
+#
+# This lives in the root manifest because cargo reads `[profile.*]` ONLY from a workspace root — the
+# same table in a member package is silently ignored. See OBOL-025.
+[profile.release]
+overflow-checks = true

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -219,8 +219,8 @@
         "usagesDigest": "ZFczeKb9JmuTj0M6dO+Xlxv2gixmzLQUYZLYY7e9dyU=",
         "recordedFileInputs": {
           "@@//Cargo.lock": "e96a0b43a50f2b739ee3d6b57e0e93db0deeac28ecc768f700e7642732ead9bb",
-          "@@//Cargo.toml": "d0888dd20868a75a8a142b91aafc9c46e1439852559bd37a8bb56547a7f9f0e2",
-          "@@//devseller/Cargo.toml": "1737e5566e1d75f8b287d6184c4e3280868af7929284a04c6160034dd84358f4",
+          "@@//Cargo.toml": "bf347c22a2ccffde8580d53873a2e62605269c283b02ba84c2d60d83765d6f1e",
+          "@@//devseller/Cargo.toml": "e02849e814502abb6b0e3e590c662c0a0f9810cdbf81640de533223f4ec66817",
           "@@//eip3009/Cargo.toml": "7bf2025dce137089a109177104b86f17ecc402a96ed33cc2390fb1d74694b497",
           "@@//obolus/Cargo.toml": "2619e6ab57a5e3f508bc60996516e962fd64cd0c7ac0f15dda263406cd7619bf"
         },

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ because there is no signing path to misuse.
 | | |
 |---|---|
 | **Shipped (A0–A2)** | 402 challenge, `X-PAYMENT` / `X-PAYMENT-RESPONSE` codec, the `Facilitator` and `Upstream` seams, the fakes, the wired gateway |
-| **Shipped (A3 rewire)** | The real HTTP clients wired into the `server` binary: `DelegatedFacilitator` (delegates `/verify` + `/settle` to a facilitator you point it at) and `OllamaUpstream` (proxies a real Ollama). The fakes are now `#[cfg(test)]`-only, so no shipped binary can select "accept every payment + real model". Live-path hardening addressed: upstream head deadline (OBOL-002 item 1), settle deadline derived from `maxTimeoutSeconds` (item 4), pooled-retry double-settle disabled (item 6) |
+| **Shipped (A3 rewire)** | The real HTTP clients wired into the `obolus` binary: `DelegatedFacilitator` (delegates `/verify` + `/settle` to a facilitator you point it at) and `OllamaUpstream` (proxies a real Ollama). The fakes are now `#[cfg(test)]`-only, so no shipped binary can select "accept every payment + real model". Live-path hardening addressed: upstream head deadline (OBOL-002 item 1), settle deadline derived from `maxTimeoutSeconds` (item 4), pooled-retry double-settle disabled (item 6) |
 | **Next (A3 e2e + fast-follows)** | The post-merge **cron** that settles a real testnet payment against a third-party facilitator (touches the network, so cron-only, never per-PR). Plus the remaining OBOL-002 fast-follows: output/generation caps (item 2), settle-failure body drain/abort (item 3), and the 4xx-verdict contract confirmation (item 5, observable only against a live facilitator) |
 | **Later (Phase B)** | A self-settling facilitator that verifies and submits on-chain itself — additive behind the same seam, gated separately |
 
@@ -42,7 +42,7 @@ without crypto, and A1's types are built to preserve it.
 | `obolus/src/facilitator.rs` | The `Facilitator` seam + `DelegatedFacilitator` (real HTTP) + the test-only `FakeFacilitator` |
 | `obolus/src/upstream.rs` | The `Upstream` seam + `OllamaUpstream` (real HTTP proxy) + the test-only `FakeUpstream` |
 | `obolus/src/gateway.rs` | Route wiring, and the decision of *when we charge* |
-| `obolus/src/main.rs` | The `server` binary, wired to the real facilitator + Ollama upstream (env-configured); testnet-by-construction |
+| `obolus/src/main.rs` | The `obolus` binary, wired to the real facilitator + Ollama upstream (env-configured); testnet-by-construction |
 | `docs/x402-ecosystem.html` | **Orientation:** what x402 is, who the participants are, the Bazaar discovery layer, and where Obolus sits on the rail. Start here if the protocol is new to you — this README assumes it |
 
 ## Build and test
@@ -62,7 +62,7 @@ do not delete the test target without a replacement.
 ## Run it locally
 
 ```bash
-OBOLUS_FACILITATOR_URL=http://127.0.0.1:8404/facilitator bazel run //obolus:server
+OBOLUS_FACILITATOR_URL=http://127.0.0.1:8404/facilitator bazel run //obolus:obolus
 ```
 
 Listens on `127.0.0.1:8403` (deliberately not 8402, which x402 client-side tooling tends to bind).
@@ -216,7 +216,7 @@ direction: an operator whose `OBOLUS_NETWORK` never reached the process would re
 that their configuration had taken effect.
 
 All four lines are checked against the real binary by `obolus/tests/server_arming.rs`, which runs the
-`server` target rather than calling the guard directly — `src/main.rs` is compiled by no other test
+`obolus` target rather than calling the guard directly — `src/main.rs` is compiled by no other test
 target, so the guard's call site would otherwise be untested. That file also drives the
 `OBOLUS_ACCEPTS` branch, not only the single-chain one: the supersession bail, a placeholder among
 real entries, and a mainnet id hidden between two testnets.
@@ -379,7 +379,7 @@ distinction between token-holders. See OBOL-007.
 ## The fake is never a gate
 
 `FakeFacilitator` accepts payments it never examined; `FakeUpstream` serves canned bytes. Both are
-now `#[cfg(test)]`-only — the `server` binary compiles the library without `cfg(test)`, so they are
+now `#[cfg(test)]`-only — the `obolus` binary compiles the library without `cfg(test)`, so they are
 physically absent from every shipped artifact and no configuration path can select "accept every
 payment and serve the real model." They exist to drive the gateway's control flow in tests, and
 nothing more.

--- a/devseller/BUILD.bazel
+++ b/devseller/BUILD.bazel
@@ -2,7 +2,7 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 
 # A package of its own rather than a second binary under //obolus, because the dual build has to
 # agree: cargo declares dependencies per PACKAGE, so an `eip3009` entry in //obolus's Cargo.toml
-# would put a signature-verification path in //obolus:server's cargo graph — the one thing
+# would put a signature-verification path in //obolus:obolus's cargo graph — the one thing
 # eip3009/BUILD.bazel's own comment says it must not be. Bazel's per-target `deps` could have
 # expressed it; cargo cannot, and a rule that holds under only one of the two builds is not a rule.
 rust_binary(
@@ -15,7 +15,7 @@ rust_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//eip3009",
-        "//obolus",
+        "//obolus:lib",
         "@crates//:anyhow",
         "@crates//:axum",
         "@crates//:serde_json",

--- a/devseller/Cargo.toml
+++ b/devseller/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 
 # A package of its own rather than a second binary inside `obolus`, because cargo dependencies are
 # declared per PACKAGE, not per binary: an `eip3009` entry under `obolus` would put a signing path
-# in `obolus`'s own `server` binary, which is exactly what that crate's invariants forbid. Bazel's
+# in `obolus`'s own `obolus` binary, which is exactly what that crate's invariants forbid. Bazel's
 # per-target `deps` would have expressed it, cargo cannot, and the two builds must not disagree.
 [dependencies]
 anyhow = "1"

--- a/devseller/src/main.rs
+++ b/devseller/src/main.rs
@@ -6,8 +6,8 @@
 //! real facilitator on a real testnet cannot be asked to reject the next payment, or to time out
 //! settlement on an authorization it has already accepted.
 //!
-//! So this binary is that seller. It stands up the same [`obolus`] gateway `server` does, over a
-//! facilitator that verifies payments offline and settles nothing.
+//! So this binary is that seller. It stands up the same [`obolus`] gateway the real binary does,
+//! over a facilitator that verifies payments offline and settles nothing.
 //!
 //! # This settles no money, which is why it refuses to look as though it might
 //!
@@ -15,12 +15,12 @@
 //! behind it was served for free — and startup therefore refuses two things outright, with no
 //! override:
 //!
-//! - **any network it cannot prove is testnet.** `server` has `OBOLUS_ALLOW_MAINNET` for the
+//! - **any network it cannot prove is testnet.** `obolus` has `OBOLUS_ALLOW_MAINNET` for the
 //!   operator who genuinely means it. This binary has no such flag: a gateway that hands out real
 //!   inference for a payment it never collects has no business advertising a chain where the
 //!   payment could have been real.
 //! - **the built-in placeholder network.** `obolus::arming::is_provably_testnet` admits it through
-//!   a clause of its own, so the check above passes it — and `server` boots on it deliberately, as
+//!   a clause of its own, so the check above passes it — and `obolus` boots on it deliberately, as
 //!   the un-configured state. Here it is useless in both directions: no client can pay a challenge
 //!   on a network no chain matches, and offline verification cannot even *run*, because the
 //!   placeholder carries no `eip155:` chain id to build an EIP-712 domain from. A harness that
@@ -54,17 +54,17 @@ use crate::config::{VerifyMode, TOKEN_NAME_VAR, TOKEN_VERSION_VAR};
 use crate::upstream::DevUpstream;
 use crate::verify::TokenDomain;
 
-/// Deliberately neither 8402 (which x402 client tooling tends to bind) nor 8403 (`server`), so a
+/// Deliberately neither 8402 (which x402 client tooling tends to bind) nor 8403 (`obolus`), so a
 /// development seller and a real gateway can run side by side without either moving.
 const DEFAULT_ADDR: &str = "127.0.0.1:8404";
 
-/// Placeholders matching `server`'s, so an operator who copies a configuration between the two
+/// Placeholders matching `obolus`'s, so an operator who copies a configuration between the two
 /// sees the same values mean the same things. Both are refused here before they can be advertised.
 const PLACEHOLDER_PAY_TO: &str = "0xTEST-PAY-TO-ADDRESS-NOT-REAL";
 const PLACEHOLDER_ASSET: &str = "0xTEST-ASSET-ADDRESS-NOT-REAL";
 
 /// The acknowledgement that turns the open-proxy refusal off. Exactly the string `"1"`, matching
-/// `OBOLUS_ALLOW_MAINNET`'s convention in `server` — the safe direction for a typo.
+/// `OBOLUS_ALLOW_MAINNET`'s convention in `obolus` — the safe direction for a typo.
 const ALLOW_OPEN_PROXY_VAR: &str = "OBOLUS_DEV_ALLOW_OPEN_PROXY";
 
 /// What `--help` prints.
@@ -208,7 +208,7 @@ async fn main() -> anyhow::Result<()> {
         max_timeout_seconds: 60,
     };
 
-    // The same two configuration doors `server` offers, through the same shared checks, so a
+    // The same two configuration doors `obolus` offers, through the same shared checks, so a
     // configuration that works against one works against the other.
     let requirements: Vec<PaymentRequirements> = match std::env::var("OBOLUS_ACCEPTS") {
         Ok(raw) if raw.trim().is_empty() => anyhow::bail!(
@@ -240,7 +240,7 @@ async fn main() -> anyhow::Result<()> {
 
     // ---- guards, all of them before anything is advertised -----------------------------------
     //
-    // Same ordering rule as `server`'s: a refused configuration must never first tell the operator
+    // Same ordering rule as `obolus`'s: a refused configuration must never first tell the operator
     // it is advertising payment options. `tests/guards.rs` checks the ordering by
     // running this binary, because exit status cannot see it — a gateway that refuses too late
     // still exits non-zero, having already advertised.

--- a/eip3009/BUILD.bazel
+++ b/eip3009/BUILD.bazel
@@ -5,7 +5,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library", "rust_test")
 # under //devseller would let one drift while both stayed green.
 exports_files(["fixtures/x402-authorization.json"])
 
-# Deliberately NOT a dependency of //obolus:server. The gateway delegates verification to a
+# Deliberately NOT a dependency of //obolus:obolus. The gateway delegates verification to a
 # facilitator and never inspects a signature; this crate exists for the development seller
 # (OBOL-018) and for anything else that needs to check an EIP-3009 authorization offline.
 rust_library(

--- a/eip3009/src/lib.rs
+++ b/eip3009/src/lib.rs
@@ -5,11 +5,11 @@
 //! signature, over this authorization, recover to this address?* — which is the question an x402
 //! facilitator answers on the `/verify` path.
 //!
-//! It is deliberately **not** a dependency of the `server` binary. That gateway delegates
+//! It is deliberately **not** a dependency of the `obolus` binary. That gateway delegates
 //! verification to a facilitator and never inspects a signature itself, so pulling secp256k1 into its
 //! graph would widen the shipped artifact's attack surface for something it does not do.
 //!
-//! The rule is scoped to `server`, not to this crate's consumers in general — it is about what the
+//! The rule is scoped to that binary, not to this crate's consumers in general — it is about what the
 //! gateway's graph contains, not about who may verify. A binary whose job *is* to inspect signatures
 //! links this crate by design: a development seller that checks payments offline, so an x402 client
 //! can be tested against a counterparty that fails on command, is the intended second consumer.

--- a/obolus/BUILD.bazel
+++ b/obolus/BUILD.bazel
@@ -3,11 +3,15 @@ load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
 # The protocol + gateway live in a library so they can be unit-tested (and, later, reused by
 # the A3 real-facilitator integration tests). The binary is a thin main.
 rust_library(
-    name = "obolus",
+    name = "lib",
     srcs = glob(
         ["src/**/*.rs"],
         exclude = ["src/main.rs"],
     ),
+    # The TARGET is `lib` so that `obolus` is free for the binary below — `bazel build //obolus` then
+    # produces a file called `obolus`, which is the name it ships under. The CRATE is still `obolus`,
+    # so every `use obolus::…` is untouched and this rename reaches no Rust source.
+    crate_name = "obolus",
     visibility = ["//visibility:public"],
     deps = [
         "@crates//:axum",
@@ -27,18 +31,21 @@ rust_library(
 # this must not be deleted without a replacement, or the build goes red on purpose.
 rust_test(
     name = "obolus_test",
-    crate = ":obolus",
+    crate = ":lib",
     deps = [
         "@crates//:ring",
         "@crates//:tower",
     ],
 )
 
+# Named for the file it produces, matching both the cargo binary and the published release asset, so
+# no step anywhere renames it. A rename is the one place the gateway and the dev seller could be
+# swapped while every name still looks right.
 rust_binary(
-    name = "server",
+    name = "obolus",
     srcs = ["src/main.rs"],
     deps = [
-        ":obolus",
+        ":lib",
         "@crates//:anyhow",
         "@crates//:axum",
         "@crates//:tokio",
@@ -48,12 +55,12 @@ rust_binary(
 # The arming guard's CALL SITE (OBOL-004). `obolus_test` above cannot cover it: it compiles
 # `crate = ":obolus"`, and src/main.rs is excluded from that library's glob — so main is compiled
 # by no test target and the only call to `check_arming` is unexercised. This target runs the real
-# `server` binary and reads startup behaviour off its stderr, which is the only vantage point from
+# `obolus` binary and reads startup behaviour off its stderr, which is the only vantage point from
 # which "the guard runs, and runs before anything is advertised" is checkable. Std-only: no new
 # crate deps. See the test's module docs for why it terminates and why it is hermetic.
 rust_test(
     name = "server_arming_test",
     srcs = ["tests/server_arming.rs"],
-    data = [":server"],
-    env = {"OBOLUS_SERVER_BIN": "$(rootpath :server)"},
+    data = [":obolus"],
+    env = {"OBOLUS_SERVER_BIN": "$(rootpath :obolus)"},
 )

--- a/obolus/src/arming.rs
+++ b/obolus/src/arming.rs
@@ -282,7 +282,7 @@ pub fn is_provably_testnet(network: &str) -> bool {
 ///
 /// # Who calls this
 ///
-/// The `server` binary, at startup. [`Gateway::new`](crate::gateway::Gateway::new) does **not** — it
+/// The `obolus` binary, at startup. [`Gateway::new`](crate::gateway::Gateway::new) does **not** — it
 /// enforces `(scheme, network)` uniqueness and nothing about testnet-ness, so a caller constructing a
 /// `Gateway` directly gets that invariant and not this one, and must run this function itself.
 /// Whether that asymmetry should be closed structurally is OBOL-008.

--- a/obolus/src/facilitator.rs
+++ b/obolus/src/facilitator.rs
@@ -7,7 +7,7 @@
 //! is identical across all three — that is the entire point of the seam.
 
 use std::future::Future;
-// Used only by the test-only fakes below and the test module; gated so the `server` binary,
+// Used only by the test-only fakes below and the test module; gated so the `obolus` binary,
 // compiled without `cfg(test)`, carries neither the imports nor the fakes that need them.
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -99,7 +99,7 @@ pub enum FakeOutcome {
 /// Note that it does not inspect `payment` at all — it *cannot*, because Phase A keeps the
 /// payload opaque. It exists to drive the gateway's control flow, not to judge payments.
 ///
-/// Gated to `cfg(test)`: the `server` binary compiles the library without `cfg(test)`, so this
+/// Gated to `cfg(test)`: the `obolus` binary compiles the library without `cfg(test)`, so this
 /// accept-anything facilitator is physically absent from it (OBOL-001) — no configuration path
 /// can select it, because it does not exist to select. The compiler is the enforcement.
 #[cfg(test)]

--- a/obolus/src/gateway.rs
+++ b/obolus/src/gateway.rs
@@ -99,7 +99,7 @@ impl<F: Facilitator, U: Upstream> Gateway<F, U> {
     /// **That guarantee does not extend to arming, and the asymmetry is deliberate — read it before
     /// relying on the paragraph above.** This constructor does *not* check that the advertised
     /// networks are testnet. That guard is [`arming::check_arming`](crate::arming::check_arming)
-    /// (OBOL-004), and it is applied by the `server` binary at startup, not here. So a caller
+    /// (OBOL-004), and it is applied by the `obolus` binary at startup, not here. So a caller
     /// constructing a `Gateway` directly — the A3 real-facilitator integration tests, a second
     /// binary, an external crate — gets the uniqueness invariant and **not** the arming one, and
     /// must run `check_arming` itself or it will advertise whatever it was handed. Whether that

--- a/obolus/src/lib.rs
+++ b/obolus/src/lib.rs
@@ -17,7 +17,7 @@
 //! what Obolus can *do*. The other half of the posture is what it *advertises*, since a 402 challenge
 //! is what a real client pays against — [`arming`] supplies the check for that, but note precisely
 //! what that means: it is a **check this library offers, not an invariant this library enforces**.
-//! `Gateway::new` does not call it. The `server` binary does, at startup, before constructing the
+//! `Gateway::new` does not call it. The `obolus` binary does, at startup, before constructing the
 //! gateway. A different consumer of this library could build a `Gateway` advertising anything at all
 //! (see OBOL-008 on whether that should be closed structurally).
 

--- a/obolus/src/main.rs
+++ b/obolus/src/main.rs
@@ -12,7 +12,7 @@
 //! network; there is no mainnet signing path in this crate.
 //!
 //! The Phase-A fakes are absent from this binary on purpose. They are `#[cfg(test)]`-only, so the
-//! `server` target — which compiles the library without `cfg(test)` — physically cannot build an
+//! `obolus` target — which compiles the library without `cfg(test)` — physically cannot build an
 //! accept-every-payment facilitator or a pretend upstream into a shipped artifact (OBOL-001). The
 //! compiler is the guarantee, not a code review.
 

--- a/obolus/src/upstream.rs
+++ b/obolus/src/upstream.rs
@@ -9,7 +9,7 @@
 //! purpose — see [`crate::gateway`] for why that split decides when we charge.
 
 use std::future::Future;
-// Used only by the test-only fake below; gated so the `server` binary carries neither.
+// Used only by the test-only fake below; gated so the `obolus` binary carries neither.
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 #[cfg(test)]
@@ -50,7 +50,7 @@ pub trait Upstream: Send + Sync + 'static {
 /// Its body is a real multi-chunk stream rather than one buffered blob, so tests exercise the
 /// gateway's streaming path instead of quietly proving that a one-chunk response works.
 ///
-/// Gated to `cfg(test)`: the `server` binary compiles the library without `cfg(test)`, so this
+/// Gated to `cfg(test)`: the `obolus` binary compiles the library without `cfg(test)`, so this
 /// fake cannot be wired into a shipped gateway (OBOL-001) — the compiler enforces it.
 #[cfg(test)]
 pub struct FakeUpstream {
@@ -81,7 +81,7 @@ impl UpstreamCalls {
 }
 
 /// The content type a well-behaved streaming model sends. Used only by the test-only
-/// [`FakeUpstream`], so it is gated to `cfg(test)` and never compiled into the `server` binary.
+/// [`FakeUpstream`], so it is gated to `cfg(test)` and never compiled into the `obolus` binary.
 #[cfg(test)]
 const EVENT_STREAM: &str = "text/event-stream";
 

--- a/obolus/tests/server_arming.rs
+++ b/obolus/tests/server_arming.rs
@@ -1,4 +1,4 @@
-//! `main`'s own behaviour exercised through the real `server` binary — the arming guard (OBOL-004)
+//! `main`'s own behaviour exercised through the real `obolus` binary — the arming guard (OBOL-004)
 //! and the bearer-token path's configuration and wiring (OBOL-007).
 //!
 //! # Why this exists as an exec test


### PR DESCRIPTION
## Summary

Publishes the binaries from this repository, on GitHub-hosted runners, with no mesh credential
anywhere in the workflow. This is what OBOL-025 exists for, and it is what OBOL-022's deletion of the
monorepo copy is blocked on — that tree is currently the only thing that builds the binary the
internal host runs, and removing it without a replacement fails *silently*: the host pins to the last
bytes ever published and goes on reporting a healthy converge.

### The rename that makes the rest simple

`//obolus:server` produced a file called `server`, while the cargo build of the same code produced
one called `obolus` and the release must ship `obolus`. That gap forced a rename step somewhere — and
a rename is the one place the gateway and the dev seller can be swapped while every name still looks
correct, which is precisely the confusion this release's labelling requirement exists to prevent.

So the target is renamed instead: **`//obolus:server` → `//obolus:obolus`**, and
`bazel build //obolus` now produces a file named `obolus`. The name was taken by the `rust_library`,
so that target becomes `//obolus:lib` with `crate_name = "obolus"` — the crate is unchanged, so no
Rust source moves and every `use obolus::…` is untouched.

Target, cargo binary and release asset now all read the same, in both builds, with no step in between
that renames anything.

That rename makes two classes of reference stale, both swept here: the label itself, and prose naming
the artifact `server`. `tests/server_arming.rs`, the `server_arming_test` target and
`OBOLUS_SERVER_BIN` are deliberately left alone — they name the *role*, not the artifact.

### The workflow

- **Targets**, per the decision recorded on OBOL-025: `aarch64-apple-darwin` on `macos-latest` (the
  one with a live consumer), `x86_64-unknown-linux-gnu` on `ubuntu-latest`,
  `aarch64-unknown-linux-gnu` on `ubuntu-24.04-arm`. x86_64 macOS skipped — GitHub retires that image
  after macOS 15.
- **`bazel test --config=release //...` then `bazel build --config=release`, natively per target.**
  Same configuration for both, which makes "the thing shipped is the thing tested" literal rather
  than approximate: `//obolus:server_arming_test` takes the binary as a `data` dependency, so the
  process the guard test exercises is the same action output that gets published — not a second
  compilation that happens to agree. That guard is the only vantage point from which "the arming
  check runs, and runs before anything is advertised" is observable at all.
- **`--config=release` lives in `.bazelrc`, not in the workflow**, so a released binary is
  reproducible with `bazel build --config=release //obolus` rather than by reading CI.
- **Artifacts are located with `cquery --output=files`, not `bazel-bin/…`.** That symlink points at
  whichever configuration built last, so it would hand over a default-mode binary if anything ever
  built without the release config first.
- **Two triggers.** A push to `main` cuts an immutable pre-release tagged `main-<sha>`, so every
  merged change has downloadable bytes without a human copying a file — what OBOL-025's Step B asks
  of this half. A `v*` tag cuts the real thing.
- **No `pull_request` trigger, deliberately.** This repository is public, so a PR carries a
  stranger's code; a workflow that runs it *and* holds a `contents: write` token is how a release
  gets replaced by whoever opened the PR. Every trigger here needs write access already. The token is
  `contents: read` at file scope and widened on exactly one job, which compiles nothing.
- **No third-party actions in the elevated job.** `gh` is preinstalled, so publishing needs no
  unpinned dependency in the step holding the write token.

`Cargo.toml` keeps `[profile.release] overflow-checks = true` so `cargo build --release` still agrees
with what ships. It sits in the root manifest because cargo reads `[profile.*]` **only** from a
workspace root — the same table in a member package is ignored silently.

`AGENTS.md` and its compressed sibling gain the `devseller/` row they were missing. That gap predates
this change but this change makes it acute: the release publishes a binary the repository's own
front-door document did not mention.

## Affected machines / services

None yet. Nothing internal consumes this until OBOL-025's Step B mirror is built, which is a separate
change. The internal publish path in the monorepo is untouched and still live, so there is no window
in which the deployed host has no source of binaries.

## Validation performed

`bazel test //...` — 5/5. `cargo test --workspace --locked` — 271 pass, 0 fail. Both after the rename
and the doc sweep.

**The release config was measured, not assumed.** `bazel aquery --config=release` shows
`-Coverflow-checks=on` on **71** Rustc actions across the whole dependency graph — tokio, axum, hyper,
ring included. The same query without the config matches **0**, so the probe discriminates rather than
always reporting success. Of 170 total Rustc actions the remaining 99 are exec-configuration build
scripts and proc-macros, whose code does not ship; adding `extra_exec_rustc_flags` accounts for exactly
all 170. The same query against `//obolus:server_arming_test` returns 72 — the graph plus the test
binary — confirming the guard test really is compiled under the configuration that produces the
artifact.

**Every branching or looping fragment of the workflow was executed locally**, extracted through the
YAML parser rather than transcribed:

- Tag-vs-branch resolution, including a case built to fail: a branch named `refs-tags-experiment` is
  *not* mistaken for a tag.
- Artifact flatten and checksum on a mock `download-artifact` layout: 4 binaries + 4 sidecars, no
  `.sha256.sha256` (the glob expands once, before the loop creates files), and a sidecar checked
  against tampered bytes is **refused**.
- The `Publish` step against a stub `gh` recording its argv: 8 asset arguments, `--prerelease` present
  once on the main path and elided on the tag path, and a title containing a space arriving as one
  argument.
- Staging and the architecture check, on this machine, which *is* the `aarch64-apple-darwin` row. The
  two other rows' patterns were run against the same artifact and **must not** match — they don't, so
  the check can actually reject a mislabelled binary. The two staged assets also hash differently and
  each identifies as itself when run, which is the copy-paste swap the rename was meant to make
  impossible.
- The release-notes heredoc, confirmed to dedent to valid markdown with list indentation intact.

**The safety claims in the release notes were checked against code, not against the ticket asserting
them.** `DEFAULT_ADDR = "127.0.0.1:8404"`; the mainnet refusal is unconditional because
`the_arming_override_is_refused_rather_than_honoured`; settlement is a synthetic no-op. The code turned
out stronger than the ticket's wording — the dangerous composition is refused outright rather than
merely defaulted away from — so the notes say that.

**Not validated:** Bazel on `macos-latest` and `ubuntu-24.04-arm` has never run in this repository's
CI, which only exercises `ubuntu-latest`. darwin-arm64 is proven on a local Apple Silicon machine —
that is what produced the staged artifacts above — so the unproven case is Linux arm64, which is the
same mechanism and not a target with a live consumer. And the workflow itself has never executed: it
cannot before merge, since no trigger fires on a pull request, and adding one would be the security
hole described above.

## Deployment steps

None. Merging is what runs it, producing a `main-<sha>` pre-release.

## Tickets addressed

OBOL-025 — DoD items 1, 2 and 3, with item 4 (already ticked as a decision) now implemented.

Still open on that ticket and **not** in this change: Step B's internal mirror, the failing-direction
verification of the *fetch* path, and OBOL-022's cross-reference.

## Rollback

Revert the commit. Nothing consumes the output yet, so a rollback strands nothing; the internal
publish path is untouched throughout. Any releases already cut can be deleted from the releases page —
they are additive, and no internal path fetches from them.
