### PR TITLE
ci: add a macOS bazel job so a darwin break is caught before merge (OBOL-025)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,44 @@ jobs:
       - name: Test
         run: bazel test //...
 
+  # The same canonical build, on the other platform this repository publishes for. `release.yml`'s
+  # publish job is `needs: build`, so one red matrix row skips it and that commit publishes nothing.
+  # Today that is discoverable only after the merge; this job surfaces the same break on the pull
+  # request.
+  #
+  # Default configuration rather than `--config=release`, deliberately, and the difference cuts both
+  # ways. At `opt-level=0` rustc enables debug assertions and overflow checks follow them, so the
+  # arithmetic behaviour the release config sets explicitly is already exercised here — but at
+  # `opt-level=3` debug assertions default off, so third-party `debug_assert!`s that run here are
+  # compiled out of what ships. No configuration of this job reaches what the release does *after*
+  # building, either: `cquery`, `cp` and a `file` check are shell against platform tools, which no
+  # test target reaches. Closing that gap means running the release matrix before merge, which
+  # `release.yml`'s trigger comment argues against.
+  #
+  # Linux arm64 is the release matrix's third runner and is not duplicated here. A broken row costs
+  # the same whichever row it is, so this is a judgement about likelihood, not cost: with this job
+  # CI covers (x86_64, Linux) and — `macos-latest` being Apple Silicon — (aarch64, Darwin). The one
+  # ungated row is aarch64 Linux, whose residual risk is the interaction of an architecture this job
+  # exercises with an OS the job above already does.
+  bazel-macos:
+    name: bazel test //... (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          # The action's cache key carries the platform, so this shares the `CI` cache name with the
+          # job above without sharing its contents. At the version pinned above the key carries
+          # platform only, not architecture — which costs nothing here, where the two jobs differ by
+          # platform. Later versions key on both, so re-read this when the pin moves.
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      - name: Test
+        run: bazel test //...
+
   cargo:
     name: cargo test --workspace --locked
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,17 @@ on:
 permissions:
   contents: read
 
-# Two merges landing together produce two distinct `main-<sha>` tags, so they cannot collide — but
-# they are serialised anyway rather than cancelled, because a cancelled run can leave a release
-# created with only part of its assets attached.
+# Two merges landing together produce two distinct `main-<sha>` tags, so they cannot collide. They
+# are serialised anyway, because a run cancelled midway can leave a release created with only part
+# of its assets attached.
+#
+# Know the limit of that before relying on it. `cancel-in-progress: false` protects the run already
+# going, but gives it no queue of useful depth behind it: by default the group holds exactly one
+# waiting run, and GitHub cancels that pending run when a newer one is queued. So a third merge
+# arriving while a release is still running evicts the second, and that commit gets no pre-release.
+# The depth is a setting rather than a fixed property of the group, which is where to look if that
+# becomes a problem. A commit with no assets is therefore not on its own evidence that something
+# broke — the run list is what separates the two, with an evicted run shown as cancelled.
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
## Summary

CI gates one runner image. The release publishes from three.

`release.yml`'s publish job declares `needs: build`, and GitHub's documented behaviour is that "if a
job fails or is skipped, all jobs that need it are skipped unless the jobs use a conditional
expression that causes the job to continue". So a macOS break does not publish a partial release — it
takes the whole release down, and that commit publishes nothing. Today that is discoverable only
after the merge.

This adds `bazel test //...` on `macos-latest` — the same canonical command the existing job runs, on
the platform that had no pre-merge gate — so the break surfaces on the pull request instead.

**The claim is deliberately no larger than that.** Three review rounds found six incorrect statements
in this change's *prose*, none of them in the twelve lines of YAML that do the work: a partial-publish
that cannot happen, a stale-"latest release" that this repo's release path cannot produce, "every
merge cuts a release" (it does not — see below), a cache key that does not carry what I said it did,
and two security/visibility claims that overstated. Each was a claim about GitHub's semantics
asserted rather than checked. The comment going into the tree has been cut back to what is verified;
the reasoning that needs sourcing lives here instead.

### A correction to `release.yml` in the same diff

Reviewing the above turned up a false statement in `release.yml`'s own concurrency comment, which is
where the version of it in this change came from. It said two merges "are serialised anyway rather
than cancelled". That holds for two and breaks at three: `cancel-in-progress: false` protects the run
already going, but GitHub cancels an existing **pending** run when a newer one is queued, and the
workflow sets no `queue:`. A third merge arriving mid-release evicts the second, and that commit gets
no pre-release.

The comment now says that, and points at the run list as the thing that separates an eviction from a
real break — the evicted run appears there as cancelled. It also states the limit precisely: the
group's depth is **one**, not zero, and that depth is a *setting* rather than a fixed property of the
group. An earlier revision of this comment said the block "does not make runs queue up behind it",
which flattens exactly the distinction the finding turns on — a queue of depth one that is
configurable is a different object from no queue at all.

Strictly this is a second concern in one diff and would normally split; it is here because it is the
same false claim as the one being fixed, in the file this change reasons about. **The behaviour is
not changed** — making every merge actually publish is a change to that concurrency block, and is now
OBOL-033.

### Why the default configuration and not `--config=release`

Measured, not assumed, and the answer is not the obvious one.

`bazel aquery` over the whole dependency graph in the default configuration finds **0** actions
carrying `-Coverflow-checks=on` and **0** carrying `-Cdebug-assertions=on`, which looks like the
release config's arithmetic behaviour is ungated. It is not: target-configuration actions build at
`opt-level=0`, and rustc's documented defaults are that debug assertions are enabled when `opt-level`
is 0, and overflow checks follow debug assertions unless set explicitly. So the default build already
panics on overflow, implicitly.

The residual gap is therefore three things, not one:

1. Defects specific to `opt-level=3`.
2. `debug_assertions` runs the other way. `.bazelrc` sets only `--compilation_mode=opt` and
   `-Coverflow-checks=on`, so at `opt-level=3` debug assertions default **off** — third-party
   `debug_assert!`s that execute in this job are compiled out of what ships.
3. The packaging steps: `cquery`, `cp`, `chmod`, and a regex over `file`'s output. Shell against
   platform tools, reachable from no test target at any configuration, and the likeliest source of a
   darwin-only break given the test suite is hermetic Rust.

(3) is the biggest and no configuration of this job would reach it.

### Why not simply run the release matrix on pull requests

It would gate all three rows, including those packaging steps. It is deliberately not done, and the
reason is narrower than an earlier draft of this section claimed.

That draft said a `pull_request` trigger would put a stranger's patch "one `if:` away from the job
holding `contents: write`". That overstates: for a pull request from a fork, GitHub downgrades write
permissions to read unless a repository setting says otherwise, so the immediate outcome would be a
403 rather than a replaced release. The argument that does hold needs no setting to be in any
particular state: **a guard you have to write correctly is worse than a trigger that does not
exist.** The publish path is currently unreachable from a pull request structurally; adding the
trigger makes it reachable and correct only so long as an `if:` stays right.

### Why macOS only

Linux arm64 is the release matrix's third runner and is not duplicated here. A broken row costs the
same whichever row it is, so this is a judgement about **likelihood**, not cost.

With this job CI covers **(x86_64, Linux)** and — `macos-latest` being Apple Silicon, which
`release.yml` relies on when it pairs that runner with `aarch64-apple-darwin` and hard-fails the row
if `file` disagrees — **(aarch64, Darwin)**. The one ungated row is `aarch64-unknown-linux-gnu`: an
architecture this job now exercises, on an OS the job above already exercises. What is left uncovered
is the interaction between them — narrower than either other row would have been, and narrower than
it was before this change.

## Affected machines / services

None. This adds a pre-merge check and corrects two comments; it changes no artifact, no published
output, and nothing that runs anywhere.

Repository-settings questions this cannot answer from inside the diff, each the difference between
delivering a gate and delivering a notification:

- If branch protection lists required checks by name, `bazel test //... (macOS)` has to be added there
  to block a merge. Until then it reports.
- "Require branches to be up to date before merging" governs a second gap: a `pull_request` check runs
  against the head merged with the base *as it stood then*, so two individually-green PRs can still
  merge into a red `main`.

## Validation performed

**The job ran on this pull request and passed.** `ci.yml` triggers on `pull_request`, and such a run
uses the workflow file from the pull request itself — which is why a new check appears here at all,
under a name that exists on no other branch. Note the precise claim: it *ran and reported*. Whether
it *gated* depends on the branch-protection setting above, which is not observable from here.

**The configuration reasoning was measured, with a negative control.** In the default configuration
`overflow-checks` and `debug-assertions` each appear **0** times across Rustc actions, while
`opt-level` appears **170** times in the same output — so the probe can see codegen flags and the two
zeros are real absence, not a blind pattern. `opt-level` resolves to `0` for target actions and `3`
for exec-configuration ones. The rustc defaults are quoted from its codegen-options reference, and
the `needs` and concurrency behaviour from GitHub's own documentation.

**The cache key was read from the action's source at the pinned version, after a first attempt got it
wrong.** `setup-bazel@0.15.0` builds its base key as ``setup-bazel-${cacheVersion}-${platform}`` —
platform only. `os.arch()` exists in that file but is not part of the key. That costs nothing *here*,
where the two jobs differ by platform, and the outcome agrees: both bazel jobs ran in one workflow run
under the same `disk-cache` name and both passed.

It matters for `release.yml`, which this change does not touch: its `ubuntu-latest` and
`ubuntu-24.04-arm` rows differ **only** by architecture, so they share a key prefix and a
`disk-cache` name. **Upstream fixed exactly that in 0.16.0**, the release immediately after the one
pinned here, so this is a version bump rather than anything to work around locally — tracked as
OBOL-034, along with the fact that the pin is four releases behind and nothing in `.github/` moves it.

That is also why the comment in this diff is **scoped to the pinned version** and says to re-read it
when the pin moves. The claim is true of 0.15.0 and false from 0.16.0 on, so an unqualified version
of it — which is what an earlier revision carried — would have been silently falsified by the bump.
Whether the sharing has actually cost anything is still not established and is recorded as open on
that ticket: a shared Bazel disk cache should mean misses, but the bazelisk cache holds an
architecture-specific binary.

**Cost, corrected.** An earlier draft priced this at three additional caches. Only the disk cache's
name carries `github.workflow`; the bazelisk and repository caches are keyed by literals that
`release.yml`'s darwin row already creates, so the added footprint is one cache, not three — against a
10 GB per-repository cap that evicts oldest-first and silently. I cannot read current usage from here;
the Actions → Caches page shows it, and the cheap mitigation if it is close is to drop `disk-cache` on
the macOS job alone.

**The YAML parses**, and `ci.yml` declares four jobs — `no-stray-notes`, `bazel`, `bazel-macos`,
`cargo` — the new one resolving to `runs-on: macos-latest` and `bazel test //...`. A discrete job
rather than a matrix keeps `no-stray-notes`, which is not platform-dependent, off a macOS runner.

**Not verified:** the branch-protection settings above; the repository setting governing write tokens
for fork pull requests; current Actions cache usage; and how a concurrency-evicted pending run renders
in the run list, which is undocumented — the comment claims only that it appears there as cancelled.

## Deployment steps

None.

## Tickets addressed

OBOL-025 — no DoD item, which is the point: the release matrix that ticket specifies had no pre-merge
gate on two of its three runner images, and that gap is not visible from the ticket's own checklist.

## Rollback

Revert the commit. Nothing depends on this check, and removing it restores the previous gating
exactly. Both `release.yml` changes are comment-only, so reverting them changes no behaviour either —
it only restores two inaccurate sentences.
