### PR TITLE
ci: hold every merged commit's release with queue: max (OBOL-033)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,16 +25,29 @@ permissions:
 # are serialised anyway, because a run cancelled midway can leave a release created with only part
 # of its assets attached.
 #
-# Know the limit of that before relying on it. `cancel-in-progress: false` protects the run already
-# going, but gives it no queue of useful depth behind it: by default the group holds exactly one
-# waiting run, and GitHub cancels that pending run when a newer one is queued. So a third merge
-# arriving while a release is still running evicts the second, and that commit gets no pre-release.
-# The depth is a setting rather than a fixed property of the group, which is where to look if that
-# becomes a problem. A commit with no assets is therefore not on its own evidence that something
-# broke — the run list is what separates the two, with an evicted run shown as cancelled.
+# `queue: max` is why every merged commit gets its release. The default is `queue: single`, which
+# holds exactly ONE pending run and cancels it when a newer one queues — so under the default a third
+# merge arriving mid-release evicts the second, and that commit publishes nothing. Nothing fails; the
+# artifact is simply absent, which is indistinguishable from a broken build until you open the run
+# list, where an evicted run shows as cancelled. `max` holds up to 100 pending runs instead, drained
+# first-in-first-out by when each began WAITING on the group rather than when it was dispatched — and
+# GitHub does not guarantee even that, so nothing here should lean on the order.
+#
+# The two keys below are a pair: `queue: max` with `cancel-in-progress: true` is a workflow validation
+# error. The hazard is INVERTING that `false`, not deleting it — `false` is also the default, so `max`
+# stays legal without the line. It stays because it states the serialisation intent above.
+#
+# The trade, so `max` is not read as strictly better: it costs latency long before it costs anything
+# else. A fresh merge now waits behind everything already queued, and three or four merges is enough
+# for that — `single` would have kept the newest one and dropped a middle one instead. The hundred
+# belongs to the other inversion: once the queue saturates, `max` cancels new arrivals, so what gets
+# shed is the NEWEST commit. That bound this repository's merge rate cannot approach — and it is a
+# bound, not "unlimited". Releases cut from a `v*` tag sit outside all of this: `group:` keys on
+# `github.ref`, so each tag gets its own group and never queues behind main's pre-releases.
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   build:


### PR DESCRIPTION
## Prerequisites
- [x] N/A — one workflow file. No code, no dependency on other open PRs.

## Summary

Adds `queue: max` to the release workflow's `concurrency` block, and rewrites the comment above it to
say why the two keys there are a pair.

**What was wrong.** The concurrency group protected the run already going, but held only *one* run
waiting behind it. `queue` defaults to `single`, which the documentation describes as: "At most one job
or workflow run can be `pending` in the concurrency group. When a new job or workflow run is queued, any
existing `pending` job or workflow run in the same group is canceled and replaced." So with a release in
flight and a second merge pending, a third merge **evicted the second** — and that commit published
nothing.

**Why nobody noticed.** Nothing failed, and no release was ever wrong. Each commit cuts its own
`main-<sha>` tag, and every main-push release is a prerelease, so an evicted run leaves no broken or
misleading artifact — it leaves *no artifact*, which reads exactly like a build that never ran. You only
see it by comparing the run list against the commit list.

`queue: max` holds up to 100 pending runs and processes them FIFO, so a burst publishes every commit in
it.

### The decision this records, and its cost

OBOL-033 asks for a choice between two costed postures rather than a fix, so `max` is stated with its
costs rather than presented as strictly better. There are **two** of them, and only one involves the
hundred.

**Latency, and it is the reachable one.** Pending runs drain in order, so under `max` a fresh merge
waits behind every commit already queued. Three or four merges in the time one release takes is enough
to feel it; `single` would have kept that newest merge and dropped a middle one instead. This is a real
cost at this repository's actual merge rate, not a theoretical one.

**Eviction, which needs the full hundred.** Once the queue saturates, `max` cancels *new arrivals*, so
what gets shed is the newest commit — the one a deploy most likely wants. Note that the inversion runs
the other way from `single`, which sheds middle commits and always keeps the newest.

`max` wins on the second because 100 pending runs in one group is unreachable here, and it is judged
acceptable on the first because **this pipeline is not a deploy path**. It cuts `main-<sha>`
*prereleases* so every merged commit has downloadable bytes; a consumer fetches a named tag rather than
"whatever is latest". And releases cut from a `v*` tag are unaffected entirely — `group:` keys on
`github.ref`, so each tag gets its own concurrency group and never queues behind main's prereleases.
An urgent version release does not wait behind a backlog.

### The two keys are a pair

`queue: max` with `cancel-in-progress: true` "is not allowed and will result in a workflow validation
error", so the two must move together. The precise hazard is **inverting** `cancel-in-progress` to
`true`, not deleting the line: `false` is also the default, so `max` stays legal if the line disappears.
The line stays because it states the serialisation intent above it, not because `max` depends on it —
and the comment now says that rather than the stronger claim it made first.

## Affected machines / services
- No machines. This is the GitHub-hosted release pipeline for this repository only. Nothing is deployed
  and no host config is touched.

## Validation performed
- **`queue` verified against GitHub's current workflow-syntax reference**, and then against a second,
  independent source. Confirmed on both: the key exists, takes `single` (default) or `max`, the quoted
  semantics for both above, and the `max` + `cancel-in-progress: true` validation error. FIFO ordering
  is keyed on *when each run began waiting on the group*, not when it was dispatched, and the reference
  adds that ordering is not guaranteed — the comment now says so rather than claiming plain FIFO.
- **Two sources, because one was not enough here.** `queue` shipped on 2026-05-07, which is recent
  enough that it postdates the training data of most models asked about it. Three separate reviewers of
  this change — one external, one internal, and me — initially carried the prior that `concurrency`
  accepts only `group` and `cancel-in-progress`, and one asserted that confidently as a high-severity
  finding. The key is real; the prior is stale. Recorded because the same trap is waiting for the next
  person to review a workflow that uses a recent platform feature.
- **No job validates this file's workflow schema before merge.** `release.yml` deliberately has no
  `pull_request` trigger — a workflow that runs a stranger's patch while holding a `contents: write`
  token is how a release gets replaced. (`ci.yml`'s `no-stray-notes` job *does* read this file, but it
  greps for stray note paths; it does not parse the workflow.) So the first execution of this change is
  the next merge to `main`, stated as a gap rather than left implied.
- Consequence if the key were wrong anyway: the workflow fails validation and the release never starts.
  **That failure is quieter than it sounds** — an invalid workflow surfaces as an annotation in the
  Actions tab and can leave the commit status green, so a green tick is not evidence it ran. That is
  also why the check below names the Actions list specifically rather than the commit status. Recovery
  is the one-line revert.
- `jj diff --summary` before push: exactly one file modified.

## Deployment steps (POST-MERGE)
- None to run. Merging is what activates it.
- **Verify**: after the merge commit lands, confirm the Release workflow started and published its
  `main-<sha>` prerelease. That is the first and only real validation of this change.

## Tickets addressed
- OBOL-033 — the workflow half. The ticket also asks for the decision to be recorded in its own text;
  that half lives outside this repository and follows separately.

## Rollback
- Revert the commit. It is a one-line config change with no runtime state and no migration; reverting
  restores `queue: single` behaviour immediately, on the next run.
