### PR TITLE
docs: move tickets, research and plans into GitHub issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Working notes are kept outside this repository. .gitignore keeps them out by default; this
-      # job is what makes that load-bearing, since an ignore rule is silently defeated by
-      # `git add -f`.
+      # Content that cannot be a public issue — session handoffs and the like — is kept outside this
+      # repository. .gitignore keeps it out by default; this job is what makes that load-bearing,
+      # since an ignore rule is silently defeated by `git add -f`.
       - name: Reject committed notes
         run: |
           if git ls-files | grep -E '(^|/)thoughts/'; then
@@ -30,11 +30,14 @@ jobs:
           echo "No note files tracked."
 
       # The subtler case: a path that is not in this repository but is still linked to. Such a link
-      # is a broken reference for anyone reading the code.
+      # is a broken reference for anyone reading the code. The pattern covers the whole directory
+      # rather than one subtree of it, and requires a character after the slash so that naming the
+      # directory itself — as AGENTS.md does — stays allowed. It is a reference *into* it that
+      # breaks.
       - name: Reject references to absent note paths
         run: |
-          if git grep -nE '(\.\./)*thoughts/shared/' -- . ':!.github/workflows/ci.yml' ':!.gitignore'; then
-            echo "::error::Source refers to a path that is not in this repository. Reference the ticket ID alone instead."
+          if git grep -nE '(\.\./)*thoughts/[A-Za-z0-9_.-]' -- . ':!.github/workflows/ci.yml' ':!.gitignore'; then
+            echo "::error::Source refers to a path that is not in this repository. Cite the GitHub issue (#N) instead, or drop the reference entirely — content that cannot be public does not become an issue."
             exit 1
           fi
           echo "No references to absent note paths."

--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,10 @@ user.bazelrc
 # derived from it — so re-include it explicitly rather than shipping the compressed form alone.
 !AGENTS.md
 
-# Working notes — research, plans, tickets, handoffs — are kept outside this repository. Ignored
-# here so a stray copy cannot be committed by accident, and enforced by the `no-stray-notes` CI
-# job — see AGENTS.md.
+# Tickets, research and plans are GitHub issues on this repository. What cannot be a public issue —
+# session handoffs, anything depending on infrastructure not published here — is kept outside the
+# repository entirely. Ignored here so a stray copy cannot be committed by accident, and enforced by
+# the `no-stray-notes` CI job — see AGENTS.md.
 thoughts/
 
 

--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -18,10 +18,15 @@ Cargo.lock=single source of truth for versions; MODULE.bazel resolves crates fro
 every test hermetic(no network|chain|model)=the ONLY merge gate; external reality(real testnet settle vs 3rd-party facilitator)=out-of-band so its flakiness can't block pipeline
 
 §PUBLIC [repo is PUBLIC — these are not style preferences]
-working notes stay out: research|plans|tickets|handoffs kept OUTSIDE this repo
-  thoughts/ gitignored AND enforced by `no-stray-notes` CI job [ignore alone defeated by git add -f]
+tickets|research|plans = GitHub issues ON THIS REPO [part of the project, not a private layer beside it→anyone reads the reasoning behind a change w/o other access]
+  cite as GitHub does: `#42` auto-links; `fixes #42` in a PR really closes the issue on merge
+  `OBOL-NNN` still THROUGHOUT the tree from the tracker predating this — NOT only `//` comments: `#` comments in build files | a string the shipped gateway PRINTS at startup | README incl. headings AND anchor links; `git grep -niE 'OBOL-[0-9]+' -- :/` = the complete list [EVERY flag load-bearing: no `-E`→`+` is LITERAL→matches NOTHING, zero not fewer, so a broken check reads CLEAN; no `:/`→searches cwd DOWN not root; no `-i`→misses README's LOWERCASED anchor links, which break the moment you rewrite the headings they target]; write no new ones
+  filing = PUBLIC+PERMANENT, edit history included; an issue body can't be quietly taken back
+anything that CANNOT be a public issue stays OUT of the repo ENTIRELY: session handoffs | research depending on infra not published here | plans that would leak something
+  →untracked thoughts dir; gitignored AND enforced by `no-stray-notes` CI job [ignore alone defeated by git add -f]
   that job ALSO rejects REFERENCES to those paths [link to a file not here = broken reference for anyone reading the code]
-cite tickets by ID alone(OBOL-004), NEVER a path [IDs stable+meaningful; paths are what the guard rejects]
+  CAN'T TELL WHICH SIDE → keep it OUT [an issue can't be unfiled; moving a note IN later costs nothing]
+write issues+PRs for BOTH audiences(agents+humans read them; padding serves neither): what changed+why, enough for a reader to act on, stop; NO throat-clearing|ceremonial sections|flourish; COMPLETE > SHORT
 public depends only on public: no internal/private repo dep; no sideways reach into sibling project; needed internal code→publish or reimplement first
 CI on GitHub-hosted runners ONLY; NEVER runs-on:self-hosted [public repo→PR runs stranger's code; self-hosted not isolated enough]; workflow token read-only
 
@@ -48,5 +53,5 @@ execute exactly one branch(first match wins, then stop):
   ~/.geekinasuit/agents/public/AGENTS.compressed.md → read+follow
   ~/.geekinasuit/agents/public/AGENTS.md → read+follow
   else → skip; done
-NOTHING here depends on that layer: §BUILD+§PUBLIC+§INVARIANTS complete standalone; a contributor who never heard of it can build/test/change correctly. chain adds HOUSE STYLE not project rules.
-public geekinasuit norms intended to be published separately later so this chain resolves for everyone, not only inside the fleet
+NOTHING here depends on that layer: §BUILD+§PUBLIC+§INVARIANTS complete standalone; a contributor who never heard of it can build/test/change correctly. chain adds HOUSE STYLE not project rules — agents on that layer file §PUBLIC's issues through their own `tickets.main.kts` front end; everyone else uses the GitHub web UI or `gh issue create` to the same effect.
+the 2 `~/.geekinasuit/` branches are NOT a fleet detail: `~/.geekinasuit/agents/public/` = where geekinasuit's OPEN-SOURCE prompt files are meant to live on ANYONE's machine → use them, put them there, chain resolves for you too. publishing that set = separate work → the branches can currently come up empty for everyone outside

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,14 +63,32 @@ third-party facilitator — runs out of band, so its flakiness cannot block the 
 
 ## Rules specific to this repository
 
-**This repository is public.** Four things follow, and none of them are style preferences.
+**This repository is public.** Five things follow, and none of them are style preferences.
 
-- **Working notes stay out.** Research, plans, tickets and handoffs are kept outside this
-  repository. `thoughts/` is gitignored here *and* enforced by the `no-stray-notes` CI job, because
-  an ignore rule alone is defeated by `git add -f`. That job also rejects **references** to those
-  paths: a link to a file that is not here is a broken reference for anyone reading the code.
-- **Cite tickets by ID alone.** `OBOL-004`, never a path to a ticket file. IDs are stable and
-  meaningful; paths are not, and paths are what the CI guard rejects.
+- **Tickets, research and plans are GitHub issues on this repository.** They are part of the
+  project rather than a private layer beside it, so anyone can read the reasoning behind a change
+  without needing access to anything else. Cite them the way GitHub does: `#42` auto-links, and
+  `fixes #42` in a pull request really does close the issue on merge. `OBOL-NNN` still appears
+  throughout the tree — not only in `//` comments, but in `#` comments in the build files, in a
+  string the shipped gateway prints at startup, and across the README including its headings and
+  its anchor links — from the tracker that predates this;
+  `git grep -niE 'OBOL-[0-9]+' -- :/` is the complete list, and every flag in it is load-bearing.
+  Without `-E` the `+` is a literal and the pattern matches nothing at all — zero, not fewer, so the
+  check reads clean exactly when it is broken. Without `:/` the search starts at your working
+  directory rather than the root. Without `-i` it misses the README's lowercased anchor links, which
+  break the moment you rewrite the headings they point at. Do not write new ones. Filing is public and
+  permanent, edit history included; an issue body is not something you can quietly take back.
+- **Anything that cannot be a public issue stays out of the repository entirely.** Session
+  handoffs, research that depends on infrastructure not published here, plans that would leak
+  something. Those belong in an untracked `thoughts/` directory, which is gitignored *and* enforced
+  by the `no-stray-notes` CI job, because an ignore rule alone is defeated by `git add -f`. That
+  job also rejects **references** to those paths: a link to a file that is not here is a broken
+  reference for anyone reading the code. When you cannot tell which side something falls on, keep it
+  out — an issue cannot be unfiled, and moving a note in later costs nothing.
+- **Write issues and pull requests for both audiences.** Agents and humans both read them, and
+  padding serves neither. State what changed and why, give a reader enough to act on, and stop —
+  no throat-clearing, no ceremonial sections, no flourish. Being complete matters more than being
+  short.
 - **Public depends only on public.** No dependency on any internal or private repository, and no
   reaching sideways into a sibling project. If something here needs a piece of internal code, the
   piece has to be published first or reimplemented.
@@ -131,6 +149,9 @@ Execute exactly one branch; first match wins, then stop:
 
 **Nothing in this repository depends on that layer.** Everything above is complete on its own, and a
 contributor who has never heard of it can build, test, and change this project correctly. The chain
-adds house style, not project rules. Public norms for geekinasuit projects are intended to be
-published separately later, so that this chain resolves for everyone rather than only inside the
-fleet.
+adds house style, not project rules — agents on that layer file the issues above through their own
+`tickets.main.kts` front end, and everyone else uses the GitHub web UI or `gh issue create` to the
+same effect. The two `~/.geekinasuit/` branches are not a fleet detail: that directory is where
+geekinasuit's open-source prompt files are meant to live on anyone's machine, so if you use them,
+put them there and this chain resolves for you too. Publishing that set is separate work, which is
+why the branches can currently come up empty for everyone outside.


### PR DESCRIPTION
## Summary

Tickets, research and plans for this repository become GitHub issues on this repository. Previously
all four working-note kinds — those three plus session handoffs — were kept outside it, which meant
the reasoning behind a change was unreadable to anyone outside the fleet that hosts the tracker.
Handoffs and anything else that cannot be public still stay out.

Four files carry that framing and all four change together:

- `AGENTS.md` / `AGENTS.compressed.md` — §PUBLIC goes from four rules to five. The working-notes
  rule splits in two (what belongs in issues, what stays out entirely), the "cite tickets by ID
  alone" rule is absorbed into the first half since the citation form is now `#42`, and a new rule
  covers how issues and PR descriptions should be written.
- `AGENTS.md` / `AGENTS.compressed.md`, again — the **chain paragraph** gains one sentence naming
  `tickets.main.kts` as how agents on the operator layer file these issues, and `gh issue create`
  as what everyone else uses. This is the only place an operator-layer tool name enters a public
  repo, and it is deliberately *not* in §PUBLIC: the chain paragraph is the one that already
  declares that layer optional, so naming the tool there keeps its promise that nothing here
  depends on it. The paragraph's closing claim also changes. It said those norms were "intended to
  be published separately later", which reads as indefinite; `~/.geekinasuit/agents/public/` is in
  fact the designated location for geekinasuit's open-source prompt files on anyone's machine, so
  the last two chain branches are an affordance for outside contributors rather than a fleet
  detail. It now says so, and says plainly that publishing the set is separate work still to come.
- `.github/workflows/ci.yml` — the `no-stray-notes` reference guard widens from `thoughts/shared/`
  to the whole directory, and its error message now names the issue number rather than a ticket ID.
- `.gitignore` — the comment above `thoughts/` said tickets live outside the repository, which is no
  longer true.

Two details worth a reviewer's attention.

**`fixes #N` now does real work here.** It is native GitHub behaviour and closes the issue on merge,
where the old cross-repository `OBOL-NNN` reference was inert text. That inversion is the single
easiest thing to carry over wrong from a repository whose tickets are files.

**The guard widened without narrowing.** The old pattern covered one subtree; a reference to
`thoughts/handoffs/x.md` or `thoughts/plans/y.md` passed it. The new pattern requires a character
after the slash, so naming the directory itself — which `AGENTS.md` does — stays legal while a
reference *into* it does not. That is deliberately narrower than a bare `thoughts/`, and avoids
growing the guard's exclusion list, which is the one place a real broken reference could hide.

Existing `OBOL-NNN` citations in source are left alone. Their disposition is a migration question,
not a rule question, and is tracked in #11. §PUBLIC warns that the residue is *not* confined to
comments — it is also in build configuration, in strings the shipped binaries print, and on the
README's front page — and names `git grep -niE 'OBOL-[0-9]+' -- :/` as the complete list rather than
carrying an enumeration that goes stale. Every flag in that command is load-bearing, and §PUBLIC
says why each one is; the rounds below are the history of finding that out.

## Round 1 review

One BLOCKING and four NITs, all threaded on the PR.

The BLOCKING was real and mine: the first draft said "some comments still cite `OBOL-NNN`", which is
a false scope predicate. `obolus/src/main.rs:377` prints `(OBOL-004)` from the shipped gateway binary
on every successful arming, `eip3009/fixtures/x402-authorization.json:10` carries an ID in a JSON
data value, and the README has three section headings. An agent scoping the migration off that
sentence would grep for `//` and miss the front page. Fixed in both forms.

One NIT taken, and it removed a fragility rather than documenting one: two files spelled the bare
`thoughts/` directory and each escaped the widened guard by a different character, so a compression
pass tightening `thoughts/ dir` to `thoughts/dir` would have tripped CI on a document whose job is
to name that directory. The compressed form now writes it without a slash at all, leaving `AGENTS.md`
as the only file relying on the escape.

Three NITs declined with reasons on their threads: the two now-inert pathspec exclusions stay as
cheap insurance, the guard-generalisation question went to #10 with a live counterexample, and the
`tickets.main.kts` placement is the deliberate call described above.

## Round 2 review

One BLOCKING and three NITs. All four taken.

The BLOCKING was the round-1 fix, half-applied: I replaced the sentence's object and left its
subject, so it still opened "Some comments still cite" and then enumerated three places that are not
comments. The compressed form had dropped the false subject, so the two forms disagreed — a §DOCS
violation the same-commit checkbox structurally cannot observe, since it attests co-commit rather
than agreement.

The fix came from a NIT in the same round rather than from patching the subject: a hand-maintained
enumeration is the fragile form of this fact. Review measured 59 lines across 20 files and found two
outside every category I had listed — `.bazelrc:20` and `Cargo.toml:28`, both build-config comments.
So the enumeration is gone. §PUBLIC now says the residue is not confined to comments, gives examples
without claiming to be exhaustive, and names `git grep -nE 'OBOL-[0-9]+'` as the complete list. That
is the second time this sentence was wrong in prose, and the claim recorded here at the time was
that a command cannot drift the way an enumeration does. Rounds 3, 4 and 5 each falsified that: the
command was cwd-relative, then case-sensitive, then missing the flag without which it matches
nothing. Left standing rather than quietly edited, because it is the most useful thing in this
description — a command is not self-verifying merely because it is executable.

The other two NITs: the deferral that said "tracked separately" while tracking nothing is now #11 —
a fair hit, in the PR arguing that exactly this belongs in a public issue here. And the
cannot-be-public rule was the only §PUBLIC entry asking for a judgment on a one-way door with no
stated default, so it now has one: when you cannot tell, keep it out.

## Round 3 review, and an external second opinion

Four NITs, no surviving BLOCKING. All four taken.

The sharpest was the third defect in a row in the same sentence, and this time it was not in the
prose at all. Round 2's remedy — `git grep -nE 'OBOL-[0-9]+'` as the complete list — is only
complete from the repository root. `git grep` without a pathspec searches from the working
directory down, so run from `obolus/` it drops the README front page and both build-config files:
two of the three counterexamples the sentence exists to give. The command now carries `-- :/`, with
a clause explaining why, so a later editor does not trim the pathspec as noise.

One correction to that finding, recorded because the thread will outlive this PR: review reported
that what survives an `obolus/`-scoped grep is "without exception comments". It is not.
`obolus/src/main.rs:379`, the string printed on every successful arming, is inside `obolus/` and
survives. One counterexample remains rather than none. The defect and the fix are unchanged.

The remaining three: the CI error message named one remedy where the split rule has two, and for
the half that stays out entirely, filing an issue is the wrong move — it now offers both. The job's
own opening comment still led with "working notes", the term this PR divides, eleven lines from the
`.gitignore` comment the PR did fix; fixing one and not its neighbour is the wrong shape of fix, so
it leads with what actually stays out. And the `-- :/` fix landed in both forms in the same commit,
flagged separately because every round so far has caught something present in one form and not the
other.

An external decorrelating review by a different model ran against the same diff. It raised five;
two survived triage. It found the error-message defect independently, before round 3's comment
landed — two reviewers with no sight of each other converging is good evidence that one was not a
matter of taste. It also observed that §PUBLIC says "do not write new ones" with nothing enforcing
it, which is the same shape as #9 one layer out. That belongs at the end of #11's Definition of
Done, since the guard cannot be added until the existing references are gone — **but it is not
there yet, and this description said it was.** See the Round 5 section: #11 is only editable by an
operator, and the text intended for it is recorded below rather than asserted as already filed. Of
the three
rejected: "five things follow but only four bullets" was a truncated-diff artifact (there are
five); "`~/.geekinasuit/agents/...` newly exposed" reads unchanged context lines as additions, and
that path is in any case the intended public location; and the regex's case-sensitivity is #10's
scope question, which round 2 also found and correctly routed there.

## Round 4 review

BLOCKING-only by the convergence rule, and it found one — the fourth defect in the same sentence,
in a fourth distinct place.

The command is case-sensitive. `README.md:99-101` carry anchor links spelled `#…-obol-004`,
`#…-obol-003` and `#…-obol-007`, and each points at a heading the case-sensitive command *does*
report. That coupling is what makes it BLOCKING rather than a miscount: #11 uses this exact command
as its acceptance test, so rewriting those three headings, running the check and getting nothing
would close the migration with three dead links on the README front page — the one place the
sentence exists to warn about. Reproduced independently: 9 case-sensitive, 12 with `-i`, differing
only in `README.md`.

Both forms now carry `-niE` and say why each flag is load-bearing. Two unposted NITs taken with it:
"the last two branches" was off against a chain list numbered to seven, and the build-config hits
*are* comments — `#` ones — so that clause now says the useful thing, which is that a Rust-shaped
search misses them.

**#11's Definition of Done is broken the same two ways and this PR cannot fix it.** The ticket
facade files a GitHub-backed issue but has no path to update one, so the correction needs an
operator with issue-edit access. It is recorded on the review thread rather than left silent — and,
after round 5 found a third gap in the same issue, written out in full at the end of this
description.

Four rounds, four real defects, all in one sentence, with CI green throughout. That is the point
review kept making about this change: nothing here observes cross-file prose consistency, so the
§DOCS checkbox attests co-commit rather than agreement, the fixture tests a regex rather than prose,
and a false sentence passes every gate. The new validation item above is the narrow fix; the general
one is not in this PR's scope.

## Round 5 review

Scoped to the new validation item and the sentence it validates. No BLOCKING in scope, and every
number in the item independently reproduced. One report-only finding, taken.

The sentence armored `:/` and `-i` as "both flags" and left `-E` bare — and `-E` is the one that
cannot be trimmed. Without it, `+` is a literal in BRE and the pattern matches **zero** lines rather
than fewer: `grep -rnc 'OBOL-[0-9]+' README.md` returns 0 against the 9 it should. A completion gate
that reads clean precisely when it is broken, which is the worst available failure direction, and
"both flags" was undercounting to two. Both forms now enumerate all three and say what each one
costs.

**Then this description found the fifth instance, in itself.** The Summary above said, in the
present tense, that §PUBLIC "names `git grep -nE 'OBOL-[0-9]+'` as the complete list" — the form
rounds 3 and 4 established is broken two ways, quoted twelve lines above the Round 4 section that
explains it would close the migration leaving three dead links on the front page. Four rounds of
fixes had all landed in `AGENTS.md`, and none of them reached the paragraph describing `AGENTS.md`.
The two earlier occurrences, in the Round 2 and Round 3 sections, are correct and stay: they report
what the command *was* at those rounds, which is history, not a claim about the file now.

The validation item was rewritten against itself too. It said `git grep` where the measurement was
actually run with `grep -rnE`, and justified the substitution by a condition — no ignored files in
the way — established from a root-level `ls`, which cannot see the unanchored patterns in
`.gitignore`. It now names the tool used and rests on the check that settles it: `grep -r`'s walk is
a superset of `git grep`'s, so the counts agree exactly when no ignored file contributes a match,
and all 20 files carrying one were confirmed tracked. A second item states what the measurement
structurally cannot see — `-- :/` is a no-op from the root, so the check cannot observe the very
defect round 3 found — rather than leaving a reader to infer that a checked box covers it.

### And a sixth, pointing at #11

The Round 3 section above claimed the missing enforcement guard "is now the last item in #11's
Definition of Done." It is not. #11 has three Definition-of-Done bullets and no enforcement item —
the claim was written as a description of a change that was never applied, because the ticket facade
that filed #11 can create a GitHub-backed issue but cannot update one, and direct issue editing is
not available to this agent. Two attempts were refused. That sentence now says so instead.

**#11 needs three edits, and they need an operator.** Recorded here in full rather than by
reference, so the correction survives independently of any working note:

1. In the opening paragraph, `git grep -nE 'OBOL-[0-9]+'` → `git grep -niE 'OBOL-[0-9]+' -- :/`.
2. In the first Definition-of-Done bullet, the same replacement. This is the one that matters: that
   bullet is the acceptance gate for the whole migration, and all three flags are load-bearing.
   Without `-E`, `+` is a literal in BRE and the gate passes vacuously from the first day. Without
   `-i`, it misses the README's lowercased anchor links, so the migration could close leaving three
   dead links on the front page. Without `-- :/`, it searches from the working directory rather than
   the root.
3. Append a fourth Definition-of-Done bullet: *A CI step that fails when a new `OBOL-NNN` appears.
   §PUBLIC says not to write new ones and nothing enforces that — the same defect as #9 one layer
   out, a rule this repository states about itself that nothing checks. The guard cannot be added
   before the rest of this issue is done, since it would fail on the existing references, so it is
   the last step rather than the first, and it is what keeps the work from silently undoing itself.*

## Affected machines / services

None. Documentation, one `.gitignore` comment, and one CI grep pattern.

## Validation performed

- [ ] kubectl dry-run passed (N/A — no manifests)
- [ ] sops decrypt verified (N/A — no secrets)
- [x] Widened guard tested in the failing direction against a fixture: it matches
      `thoughts/shared/x.md`, `../thoughts/handoffs/y.md`, `../../thoughts/plans/z.md` and
      `thoughts/research/2026-01-01-topic.md`, and does not match the bare directory name as
      `AGENTS.md` and `.gitignore` write it. Review found the fixture had a blind spot — it did not
      cover the compressed form's third spelling. That spelling no longer exists (see Round 1), so
      `AGENTS.md` is now the only file the escape has to hold for; confirmed by count, 1 and 0.
- [x] Widened guard run across the edited tree: no matches outside its own excluded files, so the
      job stays green on this commit.
- [x] §DOCS satisfied — `AGENTS.compressed.md` updated in the same commit as `AGENTS.md`.
- [x] The §PUBLIC residue sentence's own claim measured rather than asserted, which is what four
      rounds of review kept catching it for. Measured at this commit with `grep -rnE` over the
      working tree, `.git` and `.jj` excluded. That walk is a superset of what the documented
      `git grep … -- :/` sees, so the two agree exactly when no ignored file contributes a match —
      checked rather than assumed: all 20 files carrying one are tracked, by `comm` against
      `jj file list`. Case-insensitive against its case-sensitive control: 62 lines against 59,
      differing only in `README.md`, 12 against 9, and the three-line delta is exactly the anchor
      links at `README.md:99`, `:100` and `:101`. Every category the sentence names is checked against a specific line — a `//` comment
      at `obolus/src/main.rs:184`, `#` build-file comments at `.bazelrc:20` and `Cargo.toml:28`, the
      startup string at `obolus/src/main.rs:379`, and the README's headings at `:128`, `:240` and
      `:291` besides those anchors. `-E` was tested by removing it: `grep -rnc 'OBOL-[0-9]+'
      README.md` returns 0, not 9.
- [x] What that item cannot see, stated rather than implied. Run from the root, `-- :/` is a no-op,
      so this measurement is structurally blind to the working-directory defect `:/` exists to fix;
      that one was verified separately by running from `obolus/`. It does not compare `AGENTS.md`
      against `AGENTS.compressed.md`, which is the round-2 defect class, and was also checked
      separately. And it is one measurement at one commit rather than a gate — nothing in the
      repository notices if the sentence and the tree diverge afterwards, which is the general
      problem #11's last Definition-of-Done item exists to close.

## Deployment steps (POST-MERGE)

None.

## Tickets addressed

N/A — this change establishes the issue store, so there is no issue for it to cite.

## Rollback

Revert the commit. Nothing depends on the rule beyond the CI job changed in it, and reverting
restores both together.
