### PR TITLE
docs: drop citations to tickets that stay in the private tracker

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,7 +16,6 @@ try-import %workspace%/user.bazelrc
 #
 # Living here rather than in the workflow means `bazel build --config=release //obolus` reproduces
 # the published binary, instead of the incantation being knowable only by reading CI. Cargo.toml
-# carries the same setting in `[profile.release]`, so the two builds agree on arithmetic. See
-# OBOL-025.
+# carries the same setting in `[profile.release]`, so the two builds agree on arithmetic.
 build:release --compilation_mode=opt
 build:release --@rules_rust//rust/settings:extra_rustc_flags=-Coverflow-checks=on

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ serde_json = "1"
 # the request boundary.
 #
 # This lives in the root manifest because cargo reads `[profile.*]` ONLY from a workspace root — the
-# same table in a member package is silently ignored. See OBOL-025.
+# same table in a member package is silently ignored.
 [profile.release]
 overflow-checks = true

--- a/README.md
+++ b/README.md
@@ -384,7 +384,7 @@ physically absent from every shipped artifact and no configuration path can sele
 payment and serve the real model." They exist to drive the gateway's control flow in tests, and
 nothing more.
 
-We author both the client signer (STORY-056) and this verifier, so "my fake accepted my payment"
+We author both the client signer and this verifier, so "my fake accepted my payment"
 is worth nothing as evidence — a shared misunderstanding of the EIP-712 domain separator or the
 `transferWithAuthorization` struct hash makes both sides agree with each other while a real
 facilitator still rejects. The load-bearing checks are deliberately outside our own authorship:


### PR DESCRIPTION
## Prerequisites

- [ ] N/A — no parent PR.

## Summary

- Three comments in this repository cited tickets that are **not** migrating here: the release-profile
  comments in `.bazelrc` and `Cargo.toml` each ended with `See OBOL-025.`, and the README's
  "The fake is never a gate" section attributed the client signer to `STORY-056`. Neither ticket is
  about this code — one is deployment rollout, the other belongs to a different project — so both
  pointers resolve nowhere for anyone reading this repository.
- The two build comments needed **no replacement prose**. Each already states its reason in full: the
  `.bazelrc` block explains that living there makes `bazel build --config=release //obolus` reproduce
  the published binary rather than the incantation being knowable only from CI, and `Cargo.toml`
  explains that `[profile.*]` is read only from a workspace root. The trailing pointer added nothing a
  reader could use, so it is simply gone.
- The README parenthetical was doing different work and got a different treatment. *That we author both
  the client signer and this verifier* is the premise the whole paragraph rests on — it is why
  "my fake accepted my payment" is worth nothing as evidence. The claim stays; only the identifier goes.

## Validation performed

- [ ] kubectl dry-run passed (N/A — no manifests)
- [ ] sops decrypt verified (N/A — no secrets)
- [x] `grep -rnE '\b(INFRA|STORY|AGENCY|ML|SERVE|BUILD|CI|TRIAGE)-[0-9]+'` over the tree returns
      nothing — no non-`OBOL-` tracker id remains anywhere in the repository.
- [x] `grep -rn 'OBOL-025'` returns nothing.
- [x] Confirmed the two `build:release` directives in `.bazelrc` survive the comment deletion, so the
      release configuration is unchanged. Both edits are inside `#` line comments; no directive, key or
      value was touched.
- [x] Checkout verified current with `main@origin` (`jj diff --from main@origin --summary` empty)
      before grepping, so these sweeps are authoritative rather than answers from a stale tree.

## Affected machines / services

- None. Comment and prose only — no code, no build directive, no configuration value changes.

## Deployment steps (POST-MERGE)

- None.

## Tickets addressed

- see #11 — this is the **private-citation slice only**, and deliberately does not close it.

  Two things worth stating plainly. First, #11's definition of done is
  `git grep -nE 'OBOL-[0-9]+'` returning nothing; after this PR it still matches 56 lines across 18
  files, naming 11 code-domain tickets that have yet to migrate, so the ticket stays open. Second,
  **that check would
  never have caught `STORY-056`** — the regex only matches the `OBOL-` prefix, so a citation to any
  other tracker prefix is invisible to it. The DoD needs a second pattern before it can mean what it
  says.
- The `AGENTS.md` §PUBLIC residue sentence is untouched. Its deletion is gated on nothing being left to
  describe, which is not yet true.

## Rollback

- Revert the squash commit. No runtime effect either way.
