### PR TITLE
docs: repoint or retire every OBOL-NNN citation in the tree

### DIFF
--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -19,8 +19,9 @@ every test hermetic(no network|chain|model)=the ONLY merge gate; external realit
 
 §PUBLIC [repo is PUBLIC — these are not style preferences]
 tickets|research|plans = GitHub issues ON THIS REPO [part of the project, not a private layer beside it→anyone reads the reasoning behind a change w/o other access]
-  cite as GitHub does: `#42` auto-links; `fixes #42` in a PR really closes the issue on merge
-  `OBOL-NNN` still THROUGHOUT the tree from the tracker predating this — NOT only `//` comments: `#` comments in build files | a string the shipped gateway PRINTS at startup | README incl. headings AND anchor links; `git grep -niE 'OBOL-[0-9]+' -- :/` = the complete list [EVERY flag load-bearing: no `-E`→`+` is LITERAL→matches NOTHING, zero not fewer, so a broken check reads CLEAN; no `:/`→searches cwd DOWN not root; no `-i`→misses README's LOWERCASED anchor links, which break the moment you rewrite the headings they target]; write no new ones
+  cite as `#42`; `fixes #42` in a PR really closes the issue on merge
+  `#42` RENDERS AS A LINK ONLY IN CONVERSATIONS(issues|PRs|commit msgs), NOT in a repo's FILES → 2 forms here: README(read on the web w/o a checkout)=full Markdown link | source comments=bare `#42`(doesn't render, but the reader has the repo + there's one tracker it can mean)
+  NEVER cite `OBOL-NNN` = the retired private tracker's ids; nothing here resolves them
   filing = PUBLIC+PERMANENT, edit history included; an issue body can't be quietly taken back
 anything that CANNOT be a public issue stays OUT of the repo ENTIRELY: session handoffs | research depending on infra not published here | plans that would leak something
   →untracked thoughts dir; gitignored AND enforced by `no-stray-notes` CI job [ignore alone defeated by git add -f]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,17 +67,15 @@ third-party facilitator — runs out of band, so its flakiness cannot block the 
 
 - **Tickets, research and plans are GitHub issues on this repository.** They are part of the
   project rather than a private layer beside it, so anyone can read the reasoning behind a change
-  without needing access to anything else. Cite them the way GitHub does: `#42` auto-links, and
-  `fixes #42` in a pull request really does close the issue on merge. `OBOL-NNN` still appears
-  throughout the tree — not only in `//` comments, but in `#` comments in the build files, in a
-  string the shipped gateway prints at startup, and across the README including its headings and
-  its anchor links — from the tracker that predates this;
-  `git grep -niE 'OBOL-[0-9]+' -- :/` is the complete list, and every flag in it is load-bearing.
-  Without `-E` the `+` is a literal and the pattern matches nothing at all — zero, not fewer, so the
-  check reads clean exactly when it is broken. Without `:/` the search starts at your working
-  directory rather than the root. Without `-i` it misses the README's lowercased anchor links, which
-  break the moment you rewrite the headings they point at. Do not write new ones. Filing is public and
-  permanent, edit history included; an issue body is not something you can quietly take back.
+  without needing access to anything else. Cite them as `#42`, and `fixes #42` in a pull request
+  really does close the issue on merge. GitHub renders that short form as a link only in
+  conversations — issues, pull requests, commit messages — and explicitly not in the files of a
+  repository, so the citation takes two forms here. In `README.md`, read on the web by people who
+  have no checkout, write a full Markdown link. In source comments write the bare `#42`: it does
+  not render, but a contributor reading the file has the repository in front of them and there is
+  only one tracker it can mean. Never cite `OBOL-NNN` — those are the retired private tracker's
+  ids, and nothing in this repository resolves them. Filing is public and permanent, edit history
+  included; an issue body is not something you can quietly take back.
 - **Anything that cannot be a public issue stays out of the repository entirely.** Session
   handoffs, research that depends on infrastructure not published here, plans that would leak
   something. Those belong in an untracked `thoughts/` directory, which is gitignored *and* enforced

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ AI or agentic service: it answers an unpaid request with a real HTTP 402 challen
 per-request USDC micropayment, and grants passage to the model behind it. The first service it
 guards is local **Ollama** inference.
 
-Tracked as **OBOL-001**.
+Tracked as [#17](https://github.com/geekinasuit/obolus/issues/17).
 
 ## Standing alone
 
@@ -26,8 +26,8 @@ because there is no signing path to misuse.
 | | |
 |---|---|
 | **Shipped (A0–A2)** | 402 challenge, `X-PAYMENT` / `X-PAYMENT-RESPONSE` codec, the `Facilitator` and `Upstream` seams, the fakes, the wired gateway |
-| **Shipped (A3 rewire)** | The real HTTP clients wired into the `obolus` binary: `DelegatedFacilitator` (delegates `/verify` + `/settle` to a facilitator you point it at) and `OllamaUpstream` (proxies a real Ollama). The fakes are now `#[cfg(test)]`-only, so no shipped binary can select "accept every payment + real model". Live-path hardening addressed: upstream head deadline (OBOL-002 item 1), settle deadline derived from `maxTimeoutSeconds` (item 4), pooled-retry double-settle disabled (item 6) |
-| **Next (A3 e2e + fast-follows)** | The post-merge **cron** that settles a real testnet payment against a third-party facilitator (touches the network, so cron-only, never per-PR). Plus the remaining OBOL-002 fast-follows: output/generation caps (item 2), settle-failure body drain/abort (item 3), and the 4xx-verdict contract confirmation (item 5, observable only against a live facilitator) |
+| **Shipped (A3 rewire)** | The real HTTP clients wired into the `obolus` binary: `DelegatedFacilitator` (delegates `/verify` + `/settle` to a facilitator you point it at) and `OllamaUpstream` (proxies a real Ollama). The fakes are now `#[cfg(test)]`-only, so no shipped binary can select "accept every payment + real model". Live-path hardening addressed: upstream head deadline ([#31](https://github.com/geekinasuit/obolus/issues/31) item 1), settle deadline derived from `maxTimeoutSeconds` (item 4), pooled-retry double-settle disabled (item 6) |
+| **Next (A3 e2e + fast-follows)** | The post-merge **cron** that settles a real testnet payment against a third-party facilitator (touches the network, so cron-only, never per-PR). Plus the remaining [#31](https://github.com/geekinasuit/obolus/issues/31) fast-follows: output/generation caps (item 2), settle-failure body drain/abort (item 3), and — both answerable only on the first live round-trip — the 4xx-verdict contract confirmation (item 5) and whether the upstream head deadline can outlast the advertised payment window (item 7) |
 | **Later (Phase B)** | A self-settling facilitator that verifies and submits on-chain itself — additive behind the same seam, gated separately |
 
 The payment payload is **opaque** to Phase A: we decode the envelope (version / scheme /
@@ -96,9 +96,9 @@ Configuration is by environment variable:
 | `OBOLUS_PAY_TO` | placeholder | Obviously-fake by default; override for a real (testnet) network. |
 | `OBOLUS_ASSET` | placeholder | Obviously-fake by default; override for a real (testnet) network. |
 | `OBOLUS_DESCRIPTION` | `One inference request` | Free text shown in the challenge. |
-| `OBOLUS_ALLOW_MAINNET` | unset | **Arming flag.** Unset, Obolus refuses to start if **any** advertised `network` is not on its pinned testnet allowlist — a mainnet id, a typo, or a testnet x402 added after this build. Set to exactly `1` to advertise one anyway; the startup log then carries a `*** MAINNET ARMED ***` banner naming every unproven network. Anything other than `1` (`true`, `yes`, empty) does **not** arm — the safe direction for a typo. See [Refusing to advertise an unproven network](#refusing-to-advertise-an-unproven-network-obol-004). |
-| `OBOLUS_ACCEPTS` | unset | **Multi-chain override.** A JSON array of `{"network","asset","payTo","maxAmountRequired"}` objects — one per chain — advertised together in a single 402; the client picks one to pay. When set it **supersedes** the single-chain `OBOLUS_NETWORK` / `OBOLUS_ASSET` / `OBOLUS_PAY_TO` / `OBOLUS_PRICE` vars — and setting both at once is a **startup error** (the single-chain values would be inert, so the server refuses rather than advertise a config you did not intend). At most one entry per `(scheme, network)`; see [Advertising more than one chain](#advertising-more-than-one-chain-obol-003). |
-| `OBOLUS_TOKEN_PUBKEY_FILE` | unset | **Turns the bearer-token path on.** Path to an Ed25519 **public** key in PEM (`openssl pkey -pubout`). Unset, there is no token path at all and every caller pays — the previous behaviour. Set, a caller presenting a token this key verifies is served without paying; everyone else still gets the 402. A file that is missing or is not an Ed25519 public key is a startup error, not a per-request one — and so is setting this to an empty string, which would otherwise ask for a token path while naming no key to build one from. See [Serving without payment](#serving-without-payment-obol-007). |
+| `OBOLUS_ALLOW_MAINNET` | unset | **Arming flag.** Unset, Obolus refuses to start if **any** advertised `network` is not on its pinned testnet allowlist — a mainnet id, a typo, or a testnet x402 added after this build. Set to exactly `1` to advertise one anyway; the startup log then carries a `*** MAINNET ARMED ***` banner naming every unproven network. Anything other than `1` (`true`, `yes`, empty) does **not** arm — the safe direction for a typo. See [Refusing to advertise an unproven network](#refusing-to-advertise-an-unproven-network). |
+| `OBOLUS_ACCEPTS` | unset | **Multi-chain override.** A JSON array of `{"network","asset","payTo","maxAmountRequired"}` objects — one per chain — advertised together in a single 402; the client picks one to pay. When set it **supersedes** the single-chain `OBOLUS_NETWORK` / `OBOLUS_ASSET` / `OBOLUS_PAY_TO` / `OBOLUS_PRICE` vars — and setting both at once is a **startup error** (the single-chain values would be inert, so the server refuses rather than advertise a config you did not intend). At most one entry per `(scheme, network)`; see [Advertising more than one chain](#advertising-more-than-one-chain). |
+| `OBOLUS_TOKEN_PUBKEY_FILE` | unset | **Turns the bearer-token path on.** Path to an Ed25519 **public** key in PEM (`openssl pkey -pubout`). Unset, there is no token path at all and every caller pays — the previous behaviour. Set, a caller presenting a token this key verifies is served without paying; everyone else still gets the 402. A file that is missing or is not an Ed25519 public key is a startup error, not a per-request one — and so is setting this to an empty string, which would otherwise ask for a token path while naming no key to build one from. See [Serving without payment](#serving-without-payment). |
 | `OBOLUS_TOKEN_KEYS` | unset | **The multi-key form, for rotation.** A JSON array of `{"kid": "...", "file": "..."}` objects; `kid` is optional. Supersedes `OBOLUS_TOKEN_PUBKEY_FILE`, and setting **both is a startup error** — the superseded one would sit inert, and an inert *verifying* key says nothing until a token signed with it is refused. A token naming a `kid` is checked against that key first, but a `kid` that matches nothing (or is absent) does not reject the token: it is checked against the rest of the set. At most 8 keys, no `kid` repeated, no key armed twice, every named file readable — each a startup error naming the offending entry. Set-but-empty (or whitespace-only) is its own startup error rather than the both-set one, since an array that arrived empty configures nothing. See [Rotating the signing key](#rotating-the-signing-key). |
 | `OBOLUS_TOKEN_ISSUER` | **required with the keys** | The exact `iss` every honoured token must carry. Not optional and has no default: a signing key usually belongs to an identity provider rather than to one service, so with nothing to check `iss` against, every token that key has ever minted — for any audience — would buy inference here. Setting the key without this, or setting it empty, is a startup error — as is setting **this** without the key, which would otherwise be a silent no-op that 402s every caller while looking configured. |
 | `OBOLUS_TOKEN_AUDIENCE` | unset | The `aud` an honoured token must carry. Set it and `aud` is both **checked and required**. **Leave it unset and a token carrying *any* `aud` is refused** — which is most IdP-issued tokens, so this is the setting to reach for when a token that should work does not. Refusing is deliberate rather than an oversight: `aud` names the service a token was minted for, and a verifier with no expected audience cannot tell "minted for us" from "minted for the wiki". Set-but-empty is a startup error, and so is setting it without `OBOLUS_TOKEN_KEYS` or `OBOLUS_TOKEN_PUBKEY_FILE`. |
@@ -125,7 +125,7 @@ empty value takes the multi-chain door and configures nothing, while still super
 single-chain variable — so the refusal says exactly that and tells you to unset it, rather than
 handing you a JSON parser error about column 1 for a value you never meant to be JSON.
 
-## Refusing to advertise an unproven network (OBOL-004)
+## Refusing to advertise an unproven network
 
 Obolus holds no key and signs nothing. But the 402 challenge it emits **is** the real-money trigger:
 a cooperating client reads `(network, asset, pay-to)` out of it and pays against that. So "can this
@@ -153,8 +153,9 @@ network not on it refuses to boot unless `OBOLUS_ALLOW_MAINNET=1`.
 - **Comparison is byte-exact.** What the guard checks must be byte-identical to what the gateway
   advertises, or there is a gap between the verified state and the served one. A case- or
   whitespace-variant of a testnet id is therefore *not* recognised and fails closed. Normalising it
-  is OBOL-005's job, and it belongs upstream in `config::validated_option` — the single per-option
-  seam **both** configuration forms go through — so the *stored* string becomes the canonical one.
+  belongs upstream in `config::validated_option` ([#14](https://github.com/geekinasuit/obolus/issues/14))
+  — the single per-option seam **both** configuration forms go through — so the *stored* string
+  becomes the canonical one.
   Not in `parse_accepts`: that is one of the two sites that build a payment option, and the other
   (the single-chain arm of `main`, which this README's own quickstart uses) would have been left
   raw.
@@ -237,7 +238,7 @@ Note the scope of that sentence: it is about what the **guard** can prove, not a
 only an empty network, so the value is advertised and matched verbatim like any other. An operator who
 arms past this refusal has a live rail, not a dead one.
 
-## Advertising more than one chain (OBOL-003)
+## Advertising more than one chain
 
 A single Obolus can offer several chains at once — for example Base and Solana. Set `OBOLUS_ACCEPTS`
 to a JSON array with one object per chain:
@@ -286,9 +287,10 @@ startup error, naming the ignored vars — a gateway that silently advertises a 
 its operator configured is exactly the surprise to fail loudly on. It stays
 **testnet-by-construction** the same way the single-chain vars do — Obolus has no signing path, so it
 can advertise a challenge but never move funds itself. (A startup guard that refuses to *advertise* a
-non-testnet network unless explicitly armed is tracked separately as OBOL-004.)
+non-testnet network unless explicitly armed is a separate protection — see
+[Refusing to advertise an unproven network](#refusing-to-advertise-an-unproven-network).)
 
-## Serving without payment (OBOL-007)
+## Serving without payment
 
 Payment is not the only reason to serve a request. An operator running Obolus in front of their own
 model wants their own clients served directly, and wants strangers to pay — so Obolus takes a bearer
@@ -374,7 +376,7 @@ mint nothing. The Phase-A "holds no credential" posture is about key custody and
 intact.
 
 Not in this slice: revocation, token minting, per-token rate limits or accounting, and any
-distinction between token-holders. See OBOL-007.
+distinction between token-holders. See [#33](https://github.com/geekinasuit/obolus/issues/33).
 
 ## The fake is never a gate
 

--- a/devseller/src/facilitator.rs
+++ b/devseller/src/facilitator.rs
@@ -318,7 +318,7 @@ mod tests {
     #[test]
     fn a_misconfigured_token_domain_rejects_and_says_so() {
         // The failure mode this binary is most likely to hand someone: `name` and `version` are
-        // configuration (OBOL-019), and a wrong one makes every correct signature fail to recover.
+        // configuration (#13), and a wrong one makes every correct signature fail to recover.
         // The rejection has to be traceable to the domain or the client author debugs their signer
         // for an afternoon.
         let facilitator = DevFacilitator::new(

--- a/devseller/src/main.rs
+++ b/devseller/src/main.rs
@@ -398,7 +398,7 @@ async fn main() -> anyhow::Result<()> {
     eprintln!("obolus-devseller: behaviour -> {dev}");
     eprintln!("obolus-devseller: upstream -> {}", upstream::describe(&upstream, upstream_url.as_deref()));
     if dev.verify == VerifyMode::Verify {
-        // The two fields no x402 challenge carries (OBOL-019). Printed unconditionally under
+        // The two fields no x402 challenge carries (#13). Printed unconditionally under
         // `verify` because a wrong one rejects every correct signature, and the payer cannot see
         // it from their side.
         eprintln!(

--- a/devseller/src/verify.rs
+++ b/devseller/src/verify.rs
@@ -23,7 +23,7 @@
 //! four are already in the payment requirements — `verifyingContract` *is* the advertised asset,
 //! and `chainId` is the CAIP-2 network's reference. The other two are properties of the token
 //! contract that nothing in an x402 challenge carries, and the specification does not say where to
-//! get them (OBOL-019). So they are configuration here, and every rejection renders the domain it
+//! get them (#13). So they are configuration here, and every rejection renders the domain it
 //! used: a misconfigured `name` produces a signature that does not recover, and "bad signature"
 //! with no domain printed is precisely the dead end this crate exists to help someone out of.
 
@@ -128,7 +128,7 @@ pub enum VerifyError {
         "signature does not recover to the authorizing party.\n  authorization.from: {expected}\n  \
          recovered:          {recovered}\n  verified under EIP-712 domain: {domain}\n  If the \
          payer signed correctly, the domain above is wrong — name and version are properties of \
-         the token contract that no x402 challenge carries (OBOL-019). Set OBOLUS_DEV_TOKEN_NAME \
+         the token contract that no x402 challenge carries. Set OBOLUS_DEV_TOKEN_NAME \
          and OBOLUS_DEV_TOKEN_VERSION to match the contract the payer signed against."
     )]
     NotRecovered { expected: String, recovered: String, domain: String },
@@ -493,7 +493,7 @@ mod kat_tests {
     }
 
     /// The rejection has to name the domain it used, because a `name`/`version` mismatch is
-    /// invisible from the payer's side and is the likeliest cause of a failure here (OBOL-019).
+    /// invisible from the payer's side and is the likeliest cause of a failure here (#13).
     #[test]
     fn a_failed_recovery_names_the_domain_it_verified_under() {
         let doc = fixture();

--- a/devseller/tests/guards.rs
+++ b/devseller/tests/guards.rs
@@ -842,7 +842,7 @@ fn an_unknown_behaviour_mode_refuses_and_names_the_choices() {
 }
 
 /// The banner has to say which token domain it is verifying under, because x402 does not carry
-/// `name`/`version` (OBOL-019) and a wrong one rejects every correctly-signed payment with a
+/// `name`/`version` (#13) and a wrong one rejects every correctly-signed payment with a
 /// message about signature recovery. The payer cannot see it from their side at all.
 #[test]
 fn the_startup_banner_names_the_eip712_token_domain() {

--- a/eip3009/BUILD.bazel
+++ b/eip3009/BUILD.bazel
@@ -7,7 +7,7 @@ exports_files(["fixtures/x402-authorization.json"])
 
 # Deliberately NOT a dependency of //obolus:obolus. The gateway delegates verification to a
 # facilitator and never inspects a signature; this crate exists for the development seller
-# (OBOL-018) and for anything else that needs to check an EIP-3009 authorization offline.
+# (#36) and for anything else that needs to check an EIP-3009 authorization offline.
 rust_library(
     name = "eip3009",
     srcs = glob(["src/**/*.rs"]),

--- a/eip3009/fixtures/x402-authorization.json
+++ b/eip3009/fixtures/x402-authorization.json
@@ -4,10 +4,10 @@
   "source": {
     "document": "x402 specification, `exact` scheme (EVM)",
     "retrieved": "2026-08-05",
-    "note": "The `from` address also appears in serving/obolus/src/facilitator.rs's SPEC_VERIFY_* / SPEC_SETTLE_* fixtures, transcribed from the same specification."
+    "note": "The `from` address also appears in obolus/src/facilitator.rs's SPEC_VERIFY_* / SPEC_SETTLE_* fixtures, transcribed from the same specification."
   },
   "domain_provenance": {
-    "problem": "The x402 specification publishes this signature and every authorization field but NO EIP-712 domain — not the name, version, chainId or verifyingContract. As published, the payload is unverifiable: no domain means no separator, no digest, and nothing to check the signature against. That gap is OBOL-019.",
+    "problem": "The x402 specification publishes this signature and every authorization field but NO EIP-712 domain — not the name, version, chainId or verifyingContract. As published, the payload is unverifiable: no domain means no separator, no digest, and nothing to check the signature against. That gap is https://github.com/geekinasuit/obolus/issues/13.",
     "how_it_was_closed": "By one trial, not a search. A single candidate domain was stated in advance — Circle's published Base Sepolia USDC contract address, that chain's id, and the FiatTokenV2 name and version — and tested once. It recovered the payload's `from` address exactly.",
     "why_one_match_settles_it": "A wrong domain produces a different digest and therefore an essentially random recovered address. Agreeing with `from` on all 160 bits is not something a wrong guess does. The published signature is itself the attestation: it can only have been produced over this domain.",
     "why_this_is_not_curve_fitting": "The distinction is pre-registration, not luck. Searching candidate domains until one verifies would eventually match something and prove nothing, because the test would have been fitted to pass. One candidate, named before the run, either matches or does not.",

--- a/eip3009/src/kat.rs
+++ b/eip3009/src/kat.rs
@@ -218,7 +218,7 @@ fn declared_fields(type_string: &str) -> Vec<(&str, &str)> {
 /// `transfer_struct_hash` must encode its fields in the order and with the types the EIP-3009 type
 /// string declares.
 ///
-/// No published constant exists to check this hash against — that is exactly what OBOL-019 is
+/// No published constant exists to check this hash against — that is exactly what #13 is
 /// about — so this deliberately does not pin a hash the author computed. Instead it rebuilds
 /// `encodeData` straight from the *published* type string, whose own bytes are pinned by
 /// [`typehashes_match_published_constants`], and requires the implementation to agree with it.
@@ -317,7 +317,7 @@ fn every_authorization_field_changes_the_struct_hash() {
 /// The x402 specification's published payload must verify against the Base Sepolia USDC domain.
 ///
 /// The spec publishes the signature and every authorization field but **no** EIP-712 domain, so
-/// this vector was unusable as published (OBOL-019). The domain below was not found by searching:
+/// this vector was unusable as published (#13). The domain below was not found by searching:
 /// it is the single candidate stated in advance — Circle's published Base Sepolia USDC address,
 /// that chain's id, and the FiatTokenV2 name and version — and one trial either matches or does
 /// not.

--- a/obolus/BUILD.bazel
+++ b/obolus/BUILD.bazel
@@ -52,7 +52,7 @@ rust_binary(
     ],
 )
 
-# The arming guard's CALL SITE (OBOL-004). `obolus_test` above cannot cover it: it compiles
+# The arming guard's CALL SITE. `obolus_test` above cannot cover it: it compiles
 # `crate = ":obolus"`, and src/main.rs is excluded from that library's glob — so main is compiled
 # by no test target and the only call to `check_arming` is unexercised. This target runs the real
 # `obolus` binary and reads startup behaviour off its stderr, which is the only vantage point from

--- a/obolus/src/arming.rs
+++ b/obolus/src/arming.rs
@@ -1,4 +1,4 @@
-//! The startup arming guard: refuse to advertise a network we cannot prove is testnet (OBOL-004).
+//! The startup arming guard: refuse to advertise a network we cannot prove is testnet.
 //!
 //! Obolus never signs anything — it issues a 402 challenge and delegates verify/settle to a
 //! facilitator. But **the challenge it advertises is the real-money trigger**: a cooperating client
@@ -28,9 +28,9 @@
 //! Network ids are compared verbatim — no trimming, no case folding — so that what this guard checks
 //! is byte-identical to what the gateway advertises. A case- or whitespace-variant of a testnet id
 //! is therefore *not* on the allowlist and fails closed, which is the safe direction. Normalising
-//! input is OBOL-005's job, upstream at
-//! [`config::validated_option`](crate::config::validated_option) — the single per-option seam
-//! **both** configuration forms go through, so canonicalising there cannot leave one path raw.
+//! input belongs upstream at [`config::validated_option`](crate::config::validated_option), the
+//! single per-option seam **both** configuration forms go through, so canonicalising there cannot
+//! leave one path raw (#14).
 //!
 //! # Diagnosis is not admission
 //!
@@ -79,7 +79,7 @@ pub const PINNED_ON: &str = "2026-07-29";
 /// existing identifier* at a different chain, this list keeps asserting the old truth and the guard
 /// keeps admitting the id. A rename or a new chain shows up as a diff against the source; a silently
 /// reassigned reference does not, and fail-closed cannot help because the id still matches.
-/// Re-reading the source is the only detection — mechanised by OBOL-009.
+/// Re-reading the source is the only detection — mechanised by #29.
 pub const TESTNET_NETWORKS: &[&str] = &[
     // EVM (eip155:<chain id>)
     "eip155:84532",  // Base Sepolia
@@ -176,8 +176,8 @@ fn is_non_ascii(network: &str) -> bool {
 /// [`near_miss`] cannot help — a short name is not a whitespace- or case-variant of any CAIP-2 id.
 ///
 /// Structural, not a lookup table: a CAIP-2 id is `namespace:reference`, so no colon means not
-/// CAIP-2. A short-name→CAIP-2 mapping would be a second thing to keep in sync with x402, and is
-/// OBOL-005's business anyway.
+/// CAIP-2. A short-name→CAIP-2 mapping would be a second thing to keep in sync with x402, and
+/// belongs to the canonicalisation work anyway (#14).
 ///
 /// **Three deliberate non-firings**, each because the short-name story would be *false* for it: a
 /// malformed CAIP-2 attempt (`eip155:`, `:84532`) has a colon and the generic text is not misleading
@@ -196,7 +196,7 @@ fn is_not_caip2(network: &str) -> bool {
 /// **Unreachable from `main`, and kept anyway.** Both configuration paths go through
 /// [`validated_option`](crate::config::validated_option), which rejects an empty network with the
 /// same `trim().is_empty()` test. This clause is for [`check_arming`]'s *other* callers — it is
-/// `pub`, `Gateway::new` deliberately does not call it (OBOL-008), and a library consumer assembling
+/// `pub`, `Gateway::new` deliberately does not call it (#27), and a library consumer assembling
 /// requirements by hand gets no upstream validation at all. A diagnosis that is only correct because
 /// of what some other module happens to check is not a property of this one.
 fn is_empty_value(network: &str) -> bool {
@@ -273,11 +273,11 @@ pub fn is_provably_testnet(network: &str) -> bool {
 ///
 /// The guard's promise is "no network Obolus advertises is unproven", and it can only keep that
 /// promise over what it is handed. Today one gateway advertises one set. If Obolus later routes to
-/// several upstreams with per-route pricing (OBOL-006), each route's requirements must reach this
+/// several upstreams with per-route pricing (#32), each route's requirements must reach this
 /// function — the union of everything advertised, not a default set with per-route overrides applied
 /// afterwards. A route whose price is patched in after the check is a route the guard never saw.
 ///
-/// A bearer-token path that skips payment entirely (OBOL-007) needs nothing here: it advertises no
+/// A bearer-token path that skips payment entirely (#33) needs nothing here: it advertises no
 /// challenge, so there is nothing to prove testnet. The guard stays at startup either way.
 ///
 /// # Who calls this
@@ -285,7 +285,7 @@ pub fn is_provably_testnet(network: &str) -> bool {
 /// The `obolus` binary, at startup. [`Gateway::new`](crate::gateway::Gateway::new) does **not** — it
 /// enforces `(scheme, network)` uniqueness and nothing about testnet-ness, so a caller constructing a
 /// `Gateway` directly gets that invariant and not this one, and must run this function itself.
-/// Whether that asymmetry should be closed structurally is OBOL-008.
+/// Whether that asymmetry should be closed structurally is #27.
 pub fn check_arming(
     requirements: &[PaymentRequirements],
     armed: bool,
@@ -335,7 +335,7 @@ pub fn check_arming(
 /// Nothing enforces that an armed caller calls this — a struct field would not either, since a field
 /// can be ignored as easily as a function. What holds it is
 /// `an_armed_gateway_diagnoses_a_dead_entry_among_a_real_mainnet`, which runs the binary with exactly
-/// that array. Closing it structurally is OBOL-008.
+/// that array. Closing it structurally is #27.
 ///
 /// # Why by kind, and not by offender
 ///
@@ -627,7 +627,7 @@ mod tests {
     /// test passes, and a real XDC *mainnet* id boots un-armed. Every near-miss pair lives on one
     /// source row, so the adjacency that makes a slip realistic is what makes it correlated.
     /// **Re-reading the primary source stays mandatory; a green suite is not a verification of this
-    /// data.** Mechanising that re-read is OBOL-009. The testnet half is the better-attested one —
+    /// data.** Mechanising that re-read is #29. The testnet half is the better-attested one —
     /// three readers agree on all 16 ids byte-for-byte, every near-miss pair on the correct side — and
     /// it is the half that actually gates the guard.
     ///
@@ -686,7 +686,7 @@ mod tests {
         // The transcribed oracle caught exactly that case, because its rows came from the x402 page
         // rather than from this list; the six rows the rescope dropped were decorrelated by *time* as
         // well, written before anyone knew which testnet would later need a twin. The signal that
-        // closes this has to come from outside the file — OBOL-009's mechanised re-fetch-and-diff.
+        // closes this has to come from outside the file — a mechanised re-fetch-and-diff (#29).
         // Until it lands, **adding a chain here means reading the source twice, once per column.**
         assert_eq!(
             MAINNET_NETWORKS.len(),
@@ -903,7 +903,7 @@ mod tests {
     #[test]
     fn a_case_variant_of_a_testnet_id_is_not_recognised() {
         // PINNED CURRENT BEHAVIOUR, not a wish. The comparison is byte-exact, so a case-variant
-        // CAIP-2 namespace fails closed — safe, but not friendly. When OBOL-005 lands namespace-aware
+        // CAIP-2 namespace fails closed — safe, but not friendly. When #14 lands namespace-aware
         // canonicalization at `config::validated_option`, the canonical id reaches this guard and this
         // assertion should be UPDATED as an intentional consequence, not read as a regression. Verify
         // that update on **both** configuration paths; the shared per-option seam covers them by

--- a/obolus/src/config.rs
+++ b/obolus/src/config.rs
@@ -1,7 +1,7 @@
 //! Turning a multi-chain gateway configuration into the payment options a gateway advertises.
 //!
 //! A [`crate::gateway::Gateway`] can advertise several ways to pay at once — one per
-//! `(scheme, network)`, e.g. Base and Solana (OBOL-003). This module parses the operator-facing
+//! `(scheme, network)`, e.g. Base and Solana. This module parses the operator-facing
 //! `OBOLUS_ACCEPTS` form — a JSON array of per-chain entries — into [`PaymentRequirements`],
 //! folding in the gateway-wide fields and validating each amount.
 //!
@@ -143,7 +143,7 @@ pub enum EntryDefect {
 /// Build one advertised payment option, applying the validation **both** configuration forms owe.
 ///
 /// This is the single per-option seam: every field an operator can set arrives here, from either
-/// door, before it can become something a client pays against. So OBOL-005's CAIP-2 canonicalisation
+/// door, before it can become something a client pays against. So CAIP-2 canonicalisation (#14)
 /// belongs here, not in [`parse_accepts`] — landing it there would canonicalise the multi-chain path
 /// and leave the default single-chain one raw.
 ///

--- a/obolus/src/facilitator.rs
+++ b/obolus/src/facilitator.rs
@@ -100,7 +100,7 @@ pub enum FakeOutcome {
 /// payload opaque. It exists to drive the gateway's control flow, not to judge payments.
 ///
 /// Gated to `cfg(test)`: the `obolus` binary compiles the library without `cfg(test)`, so this
-/// accept-anything facilitator is physically absent from it (OBOL-001) — no configuration path
+/// accept-anything facilitator is physically absent from it (#17) — no configuration path
 /// can select it, because it does not exist to select. The compiler is the enforcement.
 #[cfg(test)]
 pub struct FakeFacilitator {
@@ -373,7 +373,7 @@ impl DelegatedFacilitator {
             settle_url: format!("{base}/settle"),
             // A pooled connection that fails the instant we hand it a request would, by default, be
             // silently retried — re-sending POST /settle and risking a double settlement. Disable
-            // the retry so the failure surfaces as `Unavailable` instead (see OBOL-002).
+            // the retry so the failure surfaces as `Unavailable` instead (see #31).
             client: Client::builder(TokioExecutor::new())
                 .retry_canceled_requests(false)
                 .build_http::<Full<Bytes>>(),
@@ -533,7 +533,7 @@ impl Facilitator for DelegatedFacilitator {
             // KNOWN GAP — `errorReason == "duplicate_settlement"` means this authorization already
             // settled on a prior call, so money *did* move; neither 402 nor 502 is right for it. Its
             // real handling is the A3 payment-keyed idempotency cache short-circuiting it to the
-            // cached receipt, and the fail-open-vs-terminal policy is Christian's call (OBOL-001).
+            // cached receipt, and the fail-open-vs-terminal policy is Christian's call (#17).
             // Until that lands it folds into this default; it is deliberately not special-cased.
             Some(false) => Err(FacilitatorError::Rejected(reject_reason(
                 parsed.error_reason.as_deref(),
@@ -867,7 +867,7 @@ mod delegated_tests {
     async fn settle_duplicate_settlement_folds_into_rejected_for_now() {
         // Pins the CURRENT behavior and its comment: `duplicate_settlement` is not special-cased in
         // Phase A — its real handling (serve the cached receipt) is the A3 idempotency cache, and
-        // the fail-open-vs-terminal policy is Christian's call (OBOL-001).
+        // the fail-open-vs-terminal policy is Christian's call (#17).
         let body = r#"{"success":false,"errorReason":"duplicate_settlement","transaction":"","network":"base-sepolia"}"#;
         let (base, _c) = serve(unused(), Canned::ok(body)).await;
         let err = DelegatedFacilitator::new(base)

--- a/obolus/src/gateway.rs
+++ b/obolus/src/gateway.rs
@@ -78,8 +78,7 @@ pub enum GatewayError {
 /// A payment-gated route in front of one upstream service.
 ///
 /// It can advertise several ways to pay at once — one entry per `(scheme, network)`, e.g. Base and
-/// Solana — and settles each request against whichever advertised option the client actually paid
-/// (OBOL-003).
+/// Solana — and settles each request against whichever advertised option the client actually paid.
 pub struct Gateway<F: Facilitator, U: Upstream> {
     facilitator: F,
     upstream: U,
@@ -98,12 +97,12 @@ impl<F: Facilitator, U: Upstream> Gateway<F, U> {
     ///
     /// **That guarantee does not extend to arming, and the asymmetry is deliberate — read it before
     /// relying on the paragraph above.** This constructor does *not* check that the advertised
-    /// networks are testnet. That guard is [`arming::check_arming`](crate::arming::check_arming)
-    /// (OBOL-004), and it is applied by the `obolus` binary at startup, not here. So a caller
+    /// networks are testnet. That guard is [`arming::check_arming`](crate::arming::check_arming),
+    /// and it is applied by the `obolus` binary at startup, not here. So a caller
     /// constructing a `Gateway` directly — the A3 real-facilitator integration tests, a second
     /// binary, an external crate — gets the uniqueness invariant and **not** the arming one, and
     /// must run `check_arming` itself or it will advertise whatever it was handed. Whether that
-    /// should be closed structurally is OBOL-008.
+    /// should be closed structurally is #27.
     pub fn new(
         facilitator: F,
         upstream: U,
@@ -671,7 +670,7 @@ mod tests {
         assert_eq!(body, FakeUpstream::streamed_text(), "the answer itself is untouched");
     }
 
-    // --- multi-chain: many advertised options, client picks one (OBOL-003) -----------------------
+    // --- multi-chain: many advertised options, client picks one ----------------------------------
 
     /// A second advertised option on a DISTINCT network, with its own asset and pay-to, so a test
     /// can tell *which* option the gateway settled against — not merely that it settled.
@@ -871,7 +870,7 @@ mod tests {
         assert!(matches!(err, GatewayError::DuplicateOption { .. }), "got {err:?}");
     }
 
-    // ---- the access branch (OBOL-007) ----
+    // ---- the access branch (#33) ----
     //
     // Every negative case asserts 402 **and** that the upstream was never reached. The status
     // alone cannot tell "refused the token" from "reached the upstream and something else went

--- a/obolus/src/lib.rs
+++ b/obolus/src/lib.rs
@@ -19,7 +19,7 @@
 //! what that means: it is a **check this library offers, not an invariant this library enforces**.
 //! `Gateway::new` does not call it. The `obolus` binary does, at startup, before constructing the
 //! gateway. A different consumer of this library could build a `Gateway` advertising anything at all
-//! (see OBOL-008 on whether that should be closed structurally).
+//! (see #27 on whether that should be closed structurally).
 
 pub mod access;
 pub mod arming;

--- a/obolus/src/main.rs
+++ b/obolus/src/main.rs
@@ -1,7 +1,7 @@
 //! The Obolus server binary — wired to a real facilitator and a real Ollama upstream.
 //!
 //! This is live-capable, and testnet-by-construction *unless an operator explicitly arms it*:
-//! startup refuses to advertise any network it cannot prove is testnet (OBOL-004, see
+//! startup refuses to advertise any network it cannot prove is testnet (see
 //! [`obolus::arming`]), and `OBOLUS_ALLOW_MAINNET=1` is the only way past that refusal. Stating the
 //! posture unconditionally would make this doc false on exactly the instance where it matters most.
 //!
@@ -13,7 +13,7 @@
 //!
 //! The Phase-A fakes are absent from this binary on purpose. They are `#[cfg(test)]`-only, so the
 //! `obolus` target — which compiles the library without `cfg(test)` — physically cannot build an
-//! accept-every-payment facilitator or a pretend upstream into a shipped artifact (OBOL-001). The
+//! accept-every-payment facilitator or a pretend upstream into a shipped artifact (#17). The
 //! compiler is the guarantee, not a code review.
 
 use std::net::SocketAddr;
@@ -181,7 +181,7 @@ async fn main() -> anyhow::Result<()> {
         max_timeout_seconds,
     };
 
-    // One Obolus can advertise several chains at once (OBOL-003). `OBOLUS_ACCEPTS`, when set, is a
+    // One Obolus can advertise several chains at once. `OBOLUS_ACCEPTS`, when set, is a
     // JSON array of `{network, asset, payTo, maxAmountRequired}` — the client picks one from the 402
     // and pays it. Unset, we build the single option from OBOLUS_NETWORK / OBOLUS_ASSET /
     // OBOLUS_PAY_TO / OBOLUS_PRICE. The `(scheme, network)` uniqueness of the resulting set is
@@ -252,7 +252,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Obolus holds no key, but the 402 challenge it advertises IS the real-money trigger: a
     // cooperating client reads (network, asset, pay-to) out of it and pays against it. So the guard
-    // sits on the advertisement (OBOL-004). Fail-closed against a pinned testnet allowlist — a
+    // sits on the advertisement. Fail-closed against a pinned testnet allowlist — a
     // mainnet id, a typo, or a testnet x402 added after this build all refuse to boot unarmed.
     //
     // Before the banner block below, deliberately: a refused configuration must never first print
@@ -376,7 +376,7 @@ async fn main() -> anyhow::Result<()> {
         // guard on this line rather than an else-branch carrying both cases.
         eprintln!(
             "obolus: testnet-by-construction — every advertised network is on the pinned \
-             testnet allowlist (OBOL-004)."
+             testnet allowlist."
         );
     }
 
@@ -451,7 +451,7 @@ async fn main() -> anyhow::Result<()> {
             (Err(_), Err(_)) => None,
         };
 
-    // The token path (OBOL-007). No key configured means no token path at all: every caller pays,
+    // The token path (#33). No key configured means no token path at all: every caller pays,
     // which is both the previous behaviour and the fail-closed direction to default to.
     let token: Option<TokenPath> = match key_source {
         None => {

--- a/obolus/src/upstream.rs
+++ b/obolus/src/upstream.rs
@@ -51,7 +51,7 @@ pub trait Upstream: Send + Sync + 'static {
 /// gateway's streaming path instead of quietly proving that a one-chunk response works.
 ///
 /// Gated to `cfg(test)`: the `obolus` binary compiles the library without `cfg(test)`, so this
-/// fake cannot be wired into a shipped gateway (OBOL-001) — the compiler enforces it.
+/// fake cannot be wired into a shipped gateway (#17) — the compiler enforces it.
 #[cfg(test)]
 pub struct FakeUpstream {
     status: StatusCode,

--- a/obolus/src/x402.rs
+++ b/obolus/src/x402.rs
@@ -84,7 +84,7 @@ impl PaymentRequired {
     ///
     /// Order is preserved: the first entry is the gateway's preferred option, but `accepts` is a
     /// menu and the client may pick any of them. This is how one gateway advertises several chains
-    /// (e.g. Base *and* Solana) in a single 402 — the client chooses which to pay (OBOL-003).
+    /// (e.g. Base *and* Solana) in a single 402 — the client chooses which to pay.
     pub fn offering_all(accepts: Vec<PaymentRequirements>) -> Self {
         Self { x402_version: X402_VERSION, accepts, error: None }
     }

--- a/obolus/tests/server_arming.rs
+++ b/obolus/tests/server_arming.rs
@@ -1,5 +1,5 @@
-//! `main`'s own behaviour exercised through the real `obolus` binary — the arming guard (OBOL-004)
-//! and the bearer-token path's configuration and wiring (OBOL-007).
+//! `main`'s own behaviour exercised through the real `obolus` binary — the arming guard
+//! and the bearer-token path's configuration and wiring (#33).
 //!
 //! # Why this exists as an exec test
 //!
@@ -223,7 +223,7 @@ const ACCEPTS_MAINNET_PLUS_PLACEHOLDER: &str = r#"[
      "payTo":"0xTEST-PAY-TO-ADDRESS-NOT-REAL","maxAmountRequired":"1000"}
 ]"#;
 
-/// The bearer-token path's startup line (OBOL-007). Asserted present by the positive case below and
+/// The bearer-token path's startup line (#33). Asserted present by the positive case below and
 /// absent by every token refusal, so — as with [`SHORT_NAME_CLAUSE`] — the two directions share one
 /// needle and the negatives cannot rot into always-true while the positive keeps this honest.
 ///
@@ -755,11 +755,11 @@ fn an_armed_all_testnet_gateway_says_the_flag_changed_nothing() {
     run.must_not_say("MAINNET ARMED");
 }
 
-// ---- the bearer-token path's call site (OBOL-007) ------------------------------------------------
+// ---- the bearer-token path's call site (#33) -----------------------------------------------------
 //
 // Same argument as the arming guard's, one feature later: `access.rs` is unit-tested to death and
 // none of it says whether `main` wires any of it up. These are the only tests that compile-and-run
-// the OBOL-007 half of `main` at all.
+// the bearer-token half of `main` at all.
 //
 // The path below is deliberately unreadable in the first four: all three configuration guards run
 // before `std::fs::read`, so a path that cannot exist still reaches every one of them, and a test


### PR DESCRIPTION
## Summary

Removes every `OBOL-NNN` citation from the tree. The private tracker's ids resolve for
nobody reading this repository, which is what #11 was filed about.

60 citations across 18 files, in three classes:

- **39 pointed at tickets that migrated** and now name the issue here — #13, #14, #17,
  #27, #29, #31, #32, #33, #36.
- **17 named OBOL-003 or OBOL-004**, which were resolved and deliberately never migrated
  because the behaviour they tracked shipped. Those say what they meant instead. In two
  cases the replacement is strictly better than a tracker id would have been: the
  multi-chain section now links the README's own "Refusing to advertise an unproven
  network" section, which is the actual explanation.
- **4 pointed at a migrated ticket but carry no citation now**, because a citation is the
  wrong shape at those four sites: a README heading and the anchor link coupled to it (an
  id in a heading is noise, and the anchor has to follow the heading), a comment that reads
  better naming the feature than the ticket, and the `devseller` runtime string, where a
  bare `#13` would reach a client author who may hold no checkout at all. Counting these
  with the 39 would claim they name an issue, and they deliberately do not.

**Two sites are operator-facing runtime text, not comments** — worth a reviewer's eye,
because they are the only behavioural lines in an otherwise prose diff:

- `obolus/src/main.rs` — the all-clear startup line the gateway prints, previously
  `…on the pinned testnet allowlist (OBOL-004).`
- `devseller/src/verify.rs` — the `#[error(…)]` domain-rejection message a client author
  sees when their signature fails to recover.

**No test pins either one, and the suite cannot be what verified this change.**
`server_arming.rs` pins the all-clear line in two halves — `must_say("testnet-by-construction")`
plus `must_say(ALL_CLEAR_CLAIM)`, which is the middle claim only — and neither reaches the tail
where the id sat, so a substring match passes with or without it. The constant's doc comment
explains why it omits the *leading* phrase: a needle collision, since the UNCONFIGURED NETWORK
message contains "NOT testnet-by-construction". It gives no reason for the tail — that end is
simply unpinned. (Separately, and not something the doc says: the same constant is a
`must_not_say` at six call sites, so it cannot simply be widened.) What stands in for the
missing test is reading the shipped bytes: both literals were read back out
of the built binaries,
which also confirms each `\` line-continuation rejoined with a single space at the seam.
That establishes they are right *today*. Nothing guards them against future drift — the next
edit to either line breaks nothing a test can see. Worth a follow-up, not a blocker here.

One reference outside that count is fixed here too, because it is the same defect wearing a
different residue class: `eip3009/fixtures/x402-authorization.json` pointed at
`serving/obolus/src/facilitator.rs`, a path from the private monorepo that does not exist in
this repository. It now names `obolus/src/facilitator.rs`, where those `SPEC_VERIFY_*` /
`SPEC_SETTLE_*` fixtures actually live. A sweep of the tree finds no other monorepo-layout path.

**That is the instance half of #10, and this PR does not close it.** #10's second half is the
one it says matters: `no-stray-notes` checks a single directory name, so `serving/…` — same
origin, same defect — passes it untouched. That guard is unchanged here, so #10 stays open.
While in that file, the `#13` in its provenance note became a full URL. #37 exists to publish
these fixtures as release assets, and a bare `#13` is unreadable to exactly the consumer that
issue is written for — the same reason the `devseller` runtime string above carries no citation.

Three README headings carried an id, and their anchor links carried its lowercased tail.
Each heading and its link are rewritten in the same edit. That coupling is exactly why the
retired check needed `-i` — a case-sensitive sweep of this tree returns 57, missing all
three anchors and leaving three dead links behind.

`AGENTS.md` §PUBLIC loses the passage describing the residue, which now has nothing to
describe. The same bullet also claimed `#42` auto-links, and GitHub's documentation says
otherwise — *"Autolinked references are not created in wikis or files in a repository."*
So the bullet now names the two forms this repository actually uses, and the diff follows
them: a full Markdown link in `README.md`, read on the web by people with no checkout, and
the bare `#42` in source comments, read by contributors who have one. `AGENTS.compressed.md`
is updated in the same commit, per §DOCS.

## Affected machines / services

None. Obolus is not a service we operate from this repository. Two shipped binaries change
one line of output each, as described above; nothing else in either is touched.

## Validation performed

- [x] `bazel test //...` — 5/5 pass (`devseller_guards_test`, `devseller_test`,
      `eip3009_test`, `obolus_test`, `server_arming_test`)
- [x] `cargo test --workspace --locked` — exit 0
- [x] The Definition of Done check returns nothing, **and is shown to have teeth**: the
      identical pattern returned 60 lines against this same tree before the edits, so the
      empty result is a swept tree and not a broken pattern.
- [x] A second sweep for the literal `OBOL-NNN`, which `[0-9]+` is structurally blind to.
      Two hits remain, both inside the new prohibition that names the retired form — an
      injunction has to name what it forbids.
- [x] Both reworded runtime literals read back out of the built binaries, because no test
      observes either one. `grep -a 'OBOL-[0-9]'` across both shipped binaries returns
      **zero** — exhaustive over what ships, rather than a spot-check of the two lines I
      knew I had touched. Same teeth demonstration as above: that pattern returns 57
      against the pre-edit survey.
- [x] Every claim this PR makes *about* an issue read back against that issue's body, not
      just against the mapping. This is what caught the README's status row: repointing it to
      #31 made it checkable, and it listed three remaining fast-follows where #31 says four.
      Item 7 is now named, grouped with item 5 under the live-round-trip gate #31's own
      Acceptance section puts them both in.
- [x] Every repointed citation checked against the migration mapping rather than counted:
      #13, #14, #17, #27, #29, #31, #32, #33 and #36 each land where the table says. A
      transposition is the failure this catches, and there is none.
- [x] The tree swept for monorepo-layout paths (`serving/`) after fixing the one in the KAT
      fixture: no other survives. The path it now names was confirmed to exist and to hold
      the `SPEC_VERIFY_*` / `SPEC_SETTLE_*` symbols the note claims are there.
- [x] Every internal README anchor enumerated, not just the three carrying ids. There are
      four; the fourth (`#rotating-the-signing-key`) is untouched.
- [x] The 25 issues filed during the migration searched for links into the three rewritten
      anchors — zero, so no issue body is left pointing at a heading that no longer exists.
- [ ] N/A — no formatting gate to satisfy. This repository has no `rustfmt.toml` and is not
      rustfmt-clean at baseline; `cargo fmt --check` reports diffs in files this PR never
      opens, and CI runs no fmt job.

One deviation worth stating plainly: #11's DoD names `git grep`, and §JJ forbids git
operations in a jj repository, so the equivalent was run as `grep -rniE 'obol-[0-9]+'` with
`.jj/` and `target/` excluded. That is a *wider* net than the DoD's, not a narrower one —
`git grep` sees only tracked files, so a plain grep can catch residue in gitignored content
that the documented check would report as clean.

## Deployment steps

None. Merging changes no running system. A future build of `obolus` or `obolus-devseller`
picks up the two reworded output lines.

## Tickets addressed

fixes #11

Also touches #10 without closing it: the instance half is fixed here, the class half is not.
See the Summary for which is which.

Two notes on #11 rather than new work:

- Its DoD asks that each migrated ticket be "reconciled against the current tree, not
  transcribed". That was done at filing time — four issues went in deliberately narrowed
  against what had already shipped, rather than copied across.
- Its DoD regex matches only `OBOL-`, so it is structurally blind to any other tracker
  prefix. This is currently **latent, not a live miss**: a sweep for `STORY-`, `INFRA-`,
  `CI-`, `BUILD-`, `AGENCY-` and `TRIAGE-` across this tree returns zero. Worth knowing
  before the check is ever reused as a general guard.

## Rollback

Revert the commit. The change is comments, prose and two output strings; nothing carries
state and nothing else depends on it.
