### PR TITLE
docs: the citation rule now turns on where a citation is read

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Reject references to absent note paths
         run: |
           if git grep -nE '(\.\./)*thoughts/[A-Za-z0-9_.-]' -- . ':!.github/workflows/ci.yml' ':!.gitignore'; then
-            echo "::error::Source refers to a path that is not in this repository. Cite the GitHub issue (#N) instead, or drop the reference entirely — content that cannot be public does not become an issue."
+            echo "::error::Source refers to a path that is not in this repository. Cite the GitHub issue instead — AGENTS.md gives the citation form for the kind of file you are in — or drop the reference entirely; content that cannot be public does not become an issue."
             exit 1
           fi
           echo "No references to absent note paths."

--- a/AGENTS.compressed.md
+++ b/AGENTS.compressed.md
@@ -20,7 +20,7 @@ every test hermetic(no network|chain|model)=the ONLY merge gate; external realit
 §PUBLIC [repo is PUBLIC — these are not style preferences]
 tickets|research|plans = GitHub issues ON THIS REPO [part of the project, not a private layer beside it→anyone reads the reasoning behind a change w/o other access]
   cite as `#42`; `fixes #42` in a PR really closes the issue on merge
-  `#42` RENDERS AS A LINK ONLY IN CONVERSATIONS(issues|PRs|commit msgs), NOT in a repo's FILES → 2 forms here: README(read on the web w/o a checkout)=full Markdown link | source comments=bare `#42`(doesn't render, but the reader has the repo + there's one tracker it can mean)
+  `#42` RENDERS AS A LINK ONLY IN CONVERSATIONS(issues|PRs|commit msgs), NOT in a repo's FILES → form depends on 2 things about WHERE IT'S READ: does the reader have this repo + does the text RENDER. prose rendered on the web(`/README.md` + everything under docs/)=full link | source comments=bare `#42`(nothing renders it, but the reader has the repo + there's one tracker it can mean) | NEITHER(a fixture a 2nd implementer reads w/o building this repo, a string a running binary prints)=full URL written out or NO citation | MARKDOWN HEADING=no citation(text becomes the anchor→an id there lands in every link pointing at it)
   NEVER cite `OBOL-NNN` = the retired private tracker's ids; nothing here resolves them
   filing = PUBLIC+PERMANENT, edit history included; an issue body can't be quietly taken back
 anything that CANNOT be a public issue stays OUT of the repo ENTIRELY: session handoffs | research depending on infra not published here | plans that would leak something

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,12 +70,17 @@ third-party facilitator — runs out of band, so its flakiness cannot block the 
   without needing access to anything else. Cite them as `#42`, and `fixes #42` in a pull request
   really does close the issue on merge. GitHub renders that short form as a link only in
   conversations — issues, pull requests, commit messages — and explicitly not in the files of a
-  repository, so the citation takes two forms here. In `README.md`, read on the web by people who
-  have no checkout, write a full Markdown link. In source comments write the bare `#42`: it does
-  not render, but a contributor reading the file has the repository in front of them and there is
-  only one tracker it can mean. Never cite `OBOL-NNN` — those are the retired private tracker's
-  ids, and nothing in this repository resolves them. Filing is public and permanent, edit history
-  included; an issue body is not something you can quietly take back.
+  repository, so which form to write depends on two things about where it will be read: whether the
+  reader has this repository, and whether the text gets rendered. Prose rendered on the web —
+  `README.md` and everything under `docs/` — takes a full link. Source comments take the bare
+  `#42`: nothing renders it, but a contributor reading the file has the repository in front of them
+  and there is only one tracker it can mean. Anything that is neither — a fixture a second
+  implementer reads without building this repository, a string a running binary prints — takes the
+  full URL written out, or no citation at all. A Markdown heading takes no citation either: its
+  text becomes the anchor, so an id embedded there ends up in every link that points at it. Never
+  cite `OBOL-NNN` — those are the retired private tracker's ids, and nothing in this repository
+  resolves them. Filing is public and permanent, edit history included; an issue body is not
+  something you can quietly take back.
 - **Anything that cannot be a public issue stays out of the repository entirely.** Session
   handoffs, research that depends on infrastructure not published here, plans that would leak
   something. Those belong in an untracked `thoughts/` directory, which is gitignored *and* enforced


### PR DESCRIPTION
## Prerequisites
- N/A

## Summary
- §PUBLIC in `AGENTS.md` said the citation "takes two forms here" — a full Markdown link in
  `README.md`, a bare `#42` in source comments. The tree already had more than two. #38 put a full
  URL in `eip3009/fixtures/x402-authorization.json` and left `devseller`'s `NotRecovered` error
  string with no citation at all. Neither of those is a README and neither is a source comment, so
  the normative file undercounted the tree it governs.
- This replaces the count with the two facts it was standing in for: whether the reader has this
  repository, and whether the text gets rendered. Rendered web prose takes a full link. A source
  comment takes the bare `#42` — nothing renders it, but the reader has the repository in front of
  them. Text that is neither takes the full URL written out, or no citation at all. A Markdown
  heading takes none, since its text becomes the anchor every link to it must repeat.
- `ci.yml`'s absent-note-path error told the contributor to cite `(#N)`, on a `git grep` that
  covers `README.md`, where the rule requires a full link. The message now points at `AGENTS.md`
  for the form rather than naming one. The grep and the exit are untouched.

## Validation performed
- kubectl dry-run: N/A — this repository has no manifests.
- sops decrypt: N/A — this change touches no secrets.
- Coverage checked against the tree rather than by construction, which is the check the old rule
  would have failed: every `#N` and `issues/N` in the repository grepped and classified. Five
  Markdown links in `README.md`; 32 bare `#N` across both crates' source comments; one full URL in
  the fixture. Excluded as non-citations: the `#42` examples inside the rule text itself, the CSS
  hex colours in `docs/x402-ecosystem.html`, and `PKCS#8` in `obolus/src/access.rs`. Review
  re-derived the census independently and reproduced it exactly.
- That census could not have found either defect review did find, and both came from reading
  sources rather than counting. `ci.yml`'s error string contains no digits, so a grep for `#N` is
  structurally unable to see it. And the fixture's clause assignment was wrong on today's tree:
  #37 has not landed, its DoD boxes are all unchecked, and its own text says the fixtures are
  "reachable only by building this repository" — so a clause about what *travels away* from the
  repository did not yet describe the one file it was written for. Keying on rendering instead is
  true of that file today, and it also resolves `docs/x402-ecosystem.html`, which is both published
  away from the repository and rendered on the web and so drew two disagreeing answers from a
  shipping-keyed rule.
- Docs plus one CI error-message string. No logic and no test changes; the `git grep` pattern and
  the exit are byte-identical. Both forms of the doc are updated in the same commit, as §DOCS
  requires.

## Affected machines / services
- GitHub Actions CI on this repository, and nothing else. The `Reject references to absent note
  paths` job prints a different error string when it fails; its `git grep` pattern and its `exit 1`
  are byte-identical, so which commits pass and which fail is unchanged.

## Deployment steps (POST-MERGE)
- None to run. Merging updates the workflow file itself, and the new error string applies from the
  next CI run onward.

## Tickets addressed
- None. This is a follow-up to #38, which introduced the case the rule did not cover. No issue was
  filed for it — the fix is smaller than the ticket would be.

## Rollback
- Revert the commit. The rule returns to its prior wording and the CI message to its prior text;
  nothing depends on either at build or run time.
