### PR TITLE
build: refresh the MODULE.bazel.lock digest for the root manifest

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -219,7 +219,7 @@
         "usagesDigest": "ZFczeKb9JmuTj0M6dO+Xlxv2gixmzLQUYZLYY7e9dyU=",
         "recordedFileInputs": {
           "@@//Cargo.lock": "e96a0b43a50f2b739ee3d6b57e0e93db0deeac28ecc768f700e7642732ead9bb",
-          "@@//Cargo.toml": "bf347c22a2ccffde8580d53873a2e62605269c283b02ba84c2d60d83765d6f1e",
+          "@@//Cargo.toml": "538f129f76ddfa0ca4ac00d3e57a9d8b4ff9161df9728c1730c96650b15edde2",
           "@@//devseller/Cargo.toml": "e02849e814502abb6b0e3e590c662c0a0f9810cdbf81640de533223f4ec66817",
           "@@//eip3009/Cargo.toml": "7bf2025dce137089a109177104b86f17ecc402a96ed33cc2390fb1d74694b497",
           "@@//obolus/Cargo.toml": "2619e6ab57a5e3f508bc60996516e962fd64cd0c7ac0f15dda263406cd7619bf"


### PR DESCRIPTION
## Summary
- `MODULE.bazel.lock` has been recording a stale sha256 for `//Cargo.toml`. The digest
  predates 4595c6f8 (#12), which edited the root manifest without regenerating the lock, so
  the lock described a manifest that no longer exists.
- The value in this change is bazel's own regenerated output, and it matches the committed
  `Cargo.toml`.
- The effect was mild — bazel re-resolves and rewrites the entry on the next run — but that
  rewrite leaves a dirty working tree for anyone who builds, which is the opposite of what
  committing a lockfile is for.

## Affected machines / services
- None. Build metadata only; no runtime or shipped artifact changes.

## Validation performed
- Hashed the committed `Cargo.toml`: `538f129f…`, matching the new recorded digest exactly.
- Hashed `Cargo.toml` at `4595c6f8`'s parent: `bf347c22…`, matching the *old* digest — which
  pins when and how it went stale rather than assuming.
- CI is the gate: `bazel test //...` and `cargo test --workspace --locked`.

## Deployment steps (POST-MERGE)
- None.

## Tickets addressed
- None.

## Rollback
- Revert the commit. Bazel regenerates the entry on its next run either way, so reverting
  restores the stale digest rather than breaking anything.
